### PR TITLE
fix predict() dimension bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ OpenBLAS/
 surmise/emulationsupport/matern_covmat.c
 
 CaseStudy/
+
+.eggs/

--- a/surmise/calibrationmethods/directbayeswoodbury.py
+++ b/surmise/calibrationmethods/directbayeswoodbury.py
@@ -211,8 +211,8 @@ def predict(predinfo, fitinfo, emu, x, args=None):
             sps.norm.rvs(0, 1, size=(emucovxhalf.shape[2]))
         predinfo['rnd'][k, :] += re
 
-    predinfo['mean'] = np.mean(emumean, 0)
-    predinfo['var'] = np.mean(varfull, 0) + np.var(emumean, 0)
+    predinfo['mean'] = np.mean(emumean, 1)
+    predinfo['var'] = np.mean(varfull, 1) + np.var(emumean, 1)
     return
 
 

--- a/surmise/calibrationmethods/mlbayeswoodbury.py
+++ b/surmise/calibrationmethods/mlbayeswoodbury.py
@@ -247,8 +247,8 @@ def predict(predinfo, fitinfo, emu, x, args=None):
             sps.norm.rvs(0, 1, size=(emucovxhalf.shape[2]))
         predinfo['rnd'][k, :] += re
 
-    predinfo['mean'] = np.mean(emumean, 0)
-    predinfo['var'] = np.mean(varfull, 0) + np.var(emumean, 0)
+    predinfo['mean'] = np.mean(emumean, 1)
+    predinfo['var'] = np.mean(varfull, 1) + np.var(emumean, 1)
     return
 
 


### PR DESCRIPTION
If calibration method has function predict(), the mean and variance should be taken over axis 1.