### PR TITLE
Major update to PCGPwM, PCGPwImpute (formerly PCGPwMatComp)

### DIFF
--- a/surmise/emulationmethods/PCGPwImpute.py
+++ b/surmise/emulationmethods/PCGPwImpute.py
@@ -1,7 +1,7 @@
 """
-PCGPwMatComp method - an extension of PCGP method (Higdon et al. 2008) to handle missingness in simulation data.
-Matrix completion methods are used to complete the data, using matrix-completion package (Duan 2020). Then,
-:py:mod:surmise.emulationmethods.PCGP is used with the completed data.
+PCGPwImpute method - an extension of PCGP method (Higdon et al. 2008) to handle missingness in simulation data.
+Missing values are first imputed using methods included in IterativeImputer in scikit-learn.
+Then, :py:mod:surmise.emulationmethods.PCGPwM is used with the completed data.
 """
 import numpy as np
 import surmise.emulationmethods.PCGPwM as semPCGPwM
@@ -16,26 +16,17 @@ except ImportError as e:  # ModuleNotFoundError introduced in Python 3.6
     print(e)
     raise ImportError('This emulation method requires installation of packages \'sklearn\' and '
                       'requires enabling of iterative imputer option.')
-try:
-    from matrix_completion import svt_solve, pmf_solve, biased_mf_solve
-except ImportError as e:  # ModuleNotFoundError introduced in Python 3.6
-    print(e)
-    raise ImportError('This emulation method requires installation of packages \'matrix_completion\' '
-                      'and \'cvxpy\'.')
-
 
 methodoptionstr = ('\nTry one of the following: '
-                   '\n\'svt\' (singular value thresholding), '
-                   '\n\'pmf\' (probabilistic matrix factorization), '
-                   '\n\'bmf\' (biased alterating least squares matrix factorization).')
-
+                   '\n\'KNN\' (k-nearest neighbor method), '
+                   '\n\'BayesianRidge\' (Bayesian ridge regression), '
+                   '\n\'RandomForest\' (random forest method).')
 
 suggeststr = '\nOtherwise, try emulation method \'PCGPwM\' to handle missing values.'
 
 
 def fit(fitinfo, x, theta, f, epsilonPC=0.001, lognugmean=-10,
-        lognugLB=-20, varconstant=1, dampalpha=0, bigM=1000, compmethod='KNN',
-        verbose=0, **kwargs):
+        lognugLB=-20, completionmethod='KNN', verbose=0, **kwargs):
     """
     The purpose of fit is to take information and plug all of our fit
     information into fitinfo, which is a python dictionary.
@@ -53,12 +44,17 @@ def fit(fitinfo, x, theta, f, epsilonPC=0.001, lognugmean=-10,
     f : numpy.ndarray
         An array of responses. Each column in f should correspond to a row in
         theta. Each row in f should correspond to a row in x.
+    epsilonPC : scalar
+        A parameter to control the number of PCs used.  The suggested range for
+        epsilonPC is (0.001, 0.1).  The larger epsilonPC is, the fewer PCs will be
+        used.  Note that epsilonPC here is *not* the unexplained variance in
+        typical principal component analysis.
     completionmethod : str
         A string variable containing the name of matrix completion method. Options
         are:
-        - \'svt\' (singular value thresholding),
-        - \'pmf\' (probabilistic matrix factorization),
-        - \'bmf\' (biased alterating least squares matrix factorization).
+        - \'KNN\' (k-nearest neighbor method),
+        - \'BayesianRidge\' (Bayesian ridge regression),
+        - \'RandomForest\' (random forest method).
 
     Returns
     -------
@@ -73,8 +69,8 @@ def fit(fitinfo, x, theta, f, epsilonPC=0.001, lognugmean=-10,
     # Check for missing or failed values
     if not np.all(np.isfinite(f)):
         fitinfo['mof'] = np.logical_not(np.isfinite(f))
-        __completef(fitinfo, compmethod=compmethod)
-        print('Completing f with method IterativeImputer:{:s}.'.format(compmethod))
+        __completef(fitinfo, compmethod=completionmethod)
+        print('Completing f with method IterativeImputer:{:s}.'.format(completionmethod))
     else:
         fitinfo['mof'] = None
         print('No missing values identified... Proceeding with PCGP method.')
@@ -83,12 +79,17 @@ def fit(fitinfo, x, theta, f, epsilonPC=0.001, lognugmean=-10,
     fitinfo['mofrows'] = None
 
     fitinfo['epsilonPC'] = epsilonPC
+
     hyp1 = lognugmean
     hyp2 = lognugLB
-    hypvarconst = np.log(varconstant) if varconstant is not None else None
 
+    # parameters that are features of PCGPwM, but irrelevant with PCGP with imputation
+    varconstant = 1
+    dampalpha = 0
+    eta = 1000
+    hypvarconst = np.log(varconstant) if varconstant is not None else None
     fitinfo['dampalpha'] = dampalpha
-    fitinfo['bigM'] = bigM
+    fitinfo['eta'] = eta
 
     # standardize function evaluations f
     __standardizef(fitinfo)
@@ -105,7 +106,7 @@ def fit(fitinfo, x, theta, f, epsilonPC=0.001, lognugmean=-10,
 
 
 def __completef(fitinfo, compmethod=None):
-    """Completes missing values in f using matrix-completion library (Duan, 2020)."""
+    """Completes missing values in f using IterativeImpute from scikit-learn."""
     f = fitinfo['f']
     if compmethod == 'KNN':
         estimator = KNeighborsRegressor()
@@ -124,31 +125,6 @@ def __completef(fitinfo, compmethod=None):
 
     fitinfo['f'] = fhat
     fitinfo['completionmethod'] = 'IterativeImputer:{:s}'.format(compmethod)
-    return
-
-
-def __completef_matrix_completion(fitinfo, method=None):
-    """Completes missing values in f using matrix-completion library (Duan, 2020)."""
-    mof = fitinfo['mof']
-    f = fitinfo['f']
-
-    if method is None or method == 'svt':
-        # Singular value thresholding
-        fhat = svt_solve(f, ~mof)
-    elif method == 'pmf':
-        # Probablistic matrix factorization
-        fhat = pmf_solve(f, ~mof, k=10, mu=1e-2)
-    elif method == 'bmf':
-        # Biased alternating least squares
-        fhat = biased_mf_solve(f, ~mof, k=10, mu=1e-2)
-    else:
-        raise ValueError('Unsupported completion method. {:s}'.format(methodoptionstr))
-
-    if not np.isfinite(fhat).all():
-        raise ValueError('Completion method {:s} failed. {:s} {:s}'.format(method, methodoptionstr, suggeststr))
-
-    fitinfo['f'] = fhat
-    fitinfo['completionmethod'] = method
     return
 
 

--- a/surmise/emulationmethods/PCGPwM.py
+++ b/surmise/emulationmethods/PCGPwM.py
@@ -12,7 +12,7 @@ from surmise.emulationsupport.matern_covmat import covmat as __covmat
 
 
 def fit(fitinfo, x, theta, f, epsilon=0.1, lognugmean=-10,
-        lognugLB=-20, **kwargs):
+        lognugLB=-20, varconstant=None, dampalpha=0.3, verbose=0, **kwargs):
     '''
     The purpose of fit is to take information and plug all of our fit
     information into fitinfo, which is a python dictionary.
@@ -51,6 +51,17 @@ def fit(fitinfo, x, theta, f, epsilon=0.1, lognugmean=-10,
     lognugLB : scalar
         A parameter to control the lower bound of the log of the nugget. The
         suggested range for lognugLB is (-24, -12).
+    varconstant : scalar
+        A multiplying constant to control the inflation (deflation) of additional
+        variances if missing values are present. Default is None, the parameter will
+        be optimized in such case. A general working range is (np.exp(-4), np.exp(4)).
+    dampalpha : scalar
+        A parameter to control the rate of increase of variance as amount of missing
+        values increases.  Default is 0.3, otherwise an appropriate range is (0, 0.5).
+        Values larger than 0.5 are permitted but it leads to poor empirical performance. 
+    verbose : scalar
+        A parameter to suppress in-method console output.  Use 0 to suppress output,
+        use 1 to show output.
 
 
     kwargs : dict, optional
@@ -61,7 +72,6 @@ def fit(fitinfo, x, theta, f, epsilon=0.1, lognugmean=-10,
     None.
 
     '''
-
     f = f.T
     # Check for missing or failed values
     if not np.all(np.isfinite(f)):
@@ -74,6 +84,9 @@ def fit(fitinfo, x, theta, f, epsilon=0.1, lognugmean=-10,
     fitinfo['epsilon'] = epsilon
     hyp1 = lognugmean
     hyp2 = lognugLB
+    hypvarconst = np.log(varconstant) if varconstant is not None else None
+
+    fitinfo['dampalpha'] = dampalpha
 
     fitinfo['theta'] = theta
     fitinfo['f'] = f
@@ -86,10 +99,14 @@ def fit(fitinfo, x, theta, f, epsilon=0.1, lognugmean=-10,
     __PCs(fitinfo)
     numpcs = fitinfo['pc'].shape[1]
 
-    print(fitinfo['method'], 'considering ', numpcs, 'PCs')
+    if verbose > 0:
+        print(fitinfo['method'], 'considering ', numpcs, 'PCs')
 
     # Fit emulators for all PCs
-    emulist = __fitGPs(fitinfo, theta, numpcs, hyp1, hyp2)
+    emulist = __fitGPs(fitinfo, theta, numpcs, hyp1, hyp2, hypvarconst)
+    fitinfo['varc_status'] = 'fixed' if varconstant is not None else 'optimized'
+    fitinfo['logvarc'] = np.array([emulist[i]['hypvarconst'] for i in range(numpcs)])
+    fitinfo['pcstdvar'] = np.exp(fitinfo['logvarc']) * fitinfo['unscaled_pcstdvar']
     fitinfo['emulist'] = emulist
 
     return
@@ -543,7 +560,7 @@ def __standardizef(fitinfo, offset=None, scale=None):
     return
 
 
-def __PCs(fitinfo, varconstant=10):
+def __PCs(fitinfo):
     "Apply PCA to reduce the dimension of `f`."
     # Extracting from input dictionary
     f = fitinfo['f']
@@ -580,11 +597,11 @@ def __PCs(fitinfo, varconstant=10):
     fitinfo['pc'] = pc * (np.sqrt(pc.shape[0]) / pcw)
     fitinfo['extravar'] = np.mean((fs - fitinfo['pc'] @
                                    fitinfo['pct'].T) ** 2, 0) * (fitinfo['scale'] ** 2)
-    fitinfo['pcstdvar'] = varconstant * pcstdvar
+    fitinfo['unscaled_pcstdvar'] = pcstdvar
     return
 
 
-def __getnewvar(fitinfo, pending, varconstant=10):
+def __getnewvar(fitinfo, pending):
     "Calculates the variances for entries where there are missing values."
     # Extracting from principal components fit dictionary.
     pct = copy.copy(fitinfo['pcto'])
@@ -602,10 +619,10 @@ def __getnewvar(fitinfo, pending, varconstant=10):
         Qmat = np.diag(epsilon / pcw ** 2) + H
         term3 = np.diag(H) - np.sum(H * spla.solve(Qmat, H, assume_a='pos'), 0)
         pcstdvar[rv, :] = 1 - (pcw ** 2 / epsilon + 1) * term3
-    return (varconstant * pcstdvar)
+    return np.exp(fitinfo['logvarc']) * pcstdvar
 
 
-def __fitGPs(fitinfo, theta, numpcs, hyp1, hyp2):
+def __fitGPs(fitinfo, theta, numpcs, hyp1, hyp2, varconstant):
     """Fit emulators for all principle components."""
     if 'emulist' in fitinfo.keys():
         hypstarts = np.zeros((numpcs, fitinfo['emulist'][0]['hyp'].shape[0]))
@@ -626,7 +643,9 @@ def __fitGPs(fitinfo, theta, numpcs, hyp1, hyp2):
                                             g=fitinfo['pc'][:, pcanum],
                                             hyp1=hyp1,
                                             hyp2=hyp2,
-                                            gvar=fitinfo['pcstdvar'][:, pcanum],
+                                            hypvarconst=varconstant,
+                                            gvar=fitinfo['unscaled_pcstdvar'][:, pcanum],
+                                            dampalpha=fitinfo['dampalpha'],
                                             hypstarts=hypstarts[hypwhere, :],
                                             hypinds=hypwhere)
             else:
@@ -634,7 +653,9 @@ def __fitGPs(fitinfo, theta, numpcs, hyp1, hyp2):
                                             g=fitinfo['pc'][:, pcanum],
                                             hyp1=hyp1,
                                             hyp2=hyp2,
-                                            gvar=fitinfo['pcstdvar'][:, pcanum])
+                                            hypvarconst=varconstant,
+                                            gvar=fitinfo['unscaled_pcstdvar'][:, pcanum],
+                                            dampalpha=fitinfo['dampalpha'])
                 hypstarts = np.zeros((numpcs, emulist[pcanum]['hyp'].shape[0]))
             emulist[pcanum]['hypind'] = min(pcanum, emulist[pcanum]['hypind'])
             hypstarts[pcanum, :] = emulist[pcanum]['hyp']
@@ -644,20 +665,23 @@ def __fitGPs(fitinfo, theta, numpcs, hyp1, hyp2):
     return emulist
 
 
-def __fitGP1d(theta, g, hyp1, hyp2, gvar=None, hypstarts=None, hypinds=None,
+def __fitGP1d(theta, g, hyp1, hyp2, hypvarconst, gvar=None, dampalpha=None, hypstarts=None, hypinds=None,
               prevsubmodel=None):
     """Return a fitted model from the emulator model using smart method."""
+    hypvarconstmean = 4 if hypvarconst is None else hypvarconst
+    hypvarconstLB = -8 if hypvarconst is None else hypvarconst - 0.5
+    hypvarconstUB = 8 if hypvarconst is None else hypvarconst + 0.5
 
     subinfo = {}
     subinfo['hypregmean'] = np.append(0 + 0.5 * np.log(theta.shape[1]) +
-                                      np.log(np.std(theta, 0)), (0, hyp1))
+                                      np.log(np.std(theta, 0)), (0, hypvarconstmean, hyp1))
     subinfo['hypregLB'] = np.append(-4 + 0.5 * np.log(theta.shape[1]) +
-                                    np.log(np.std(theta, 0)), (-12, hyp2))
+                                    np.log(np.std(theta, 0)), (-12, hypvarconstLB, hyp2))
 
     subinfo['hypregUB'] = np.append(4 + 0.5 * np.log(theta.shape[1]) +
-                                    np.log(np.std(theta, 0)), (2, 0))
+                                    np.log(np.std(theta, 0)), (2, hypvarconstUB, 0))
     subinfo['hypregstd'] = (subinfo['hypregUB'] - subinfo['hypregLB']) / 8
-    subinfo['hypregstd'][-2] = 2
+    subinfo['hypregstd'][-3] = 2
     subinfo['hypregstd'][-1] = 4
     subinfo['hyp'] = 1 * subinfo['hypregmean']
     nhyptrain = np.max(np.min((20 * theta.shape[1], theta.shape[0])))
@@ -667,6 +691,10 @@ def __fitGP1d(theta, g, hyp1, hyp2, gvar=None, hypstarts=None, hypinds=None,
         thetac = range(0, theta.shape[0])
     subinfo['theta'] = theta[thetac, :]
     subinfo['g'] = g[thetac]
+
+    maxgvar = np.max(gvar)
+    gvar = gvar / ((np.abs(maxgvar*1.001 - gvar)) ** dampalpha)
+
     subinfo['gvar'] = gvar[thetac]
     hypind0 = -1
 
@@ -719,7 +747,8 @@ def __fitGP1d(theta, g, hyp1, hyp2, gvar=None, hypstarts=None, hypinds=None,
         likdiff = 0
     if hypind0 > -0.5 and (2 * likdiff) < 1.25 * \
             (subinfo['hyp'].shape[0] + 5 * np.sqrt(subinfo['hyp'].shape[0])):
-        subinfo['hypcov'] = subinfo['hyp'][:-1]
+        subinfo['hypcov'] = subinfo['hyp'][:-2]
+        subinfo['hypvarconst'] = subinfo['hyp'][-2]
         subinfo['hypind'] = hypind0
         subinfo['nug'] = np.exp(subinfo['hyp'][-1]) / (1 + np.exp(subinfo['hyp'][-1]))
 
@@ -727,7 +756,7 @@ def __fitGP1d(theta, g, hyp1, hyp2, gvar=None, hypstarts=None, hypinds=None,
 
         subinfo['R'] = (1 - subinfo['nug']) * R + subinfo['nug'] * np.eye(R.shape[0])
         if gvar is not None:
-            subinfo['R'] += np.diag(gvar)
+            subinfo['R'] += np.exp(subinfo['hypvarconst'])*np.diag(gvar)
 
         W, V = np.linalg.eigh(subinfo['R'])
         Vh = V / np.sqrt(np.abs(W))
@@ -739,13 +768,14 @@ def __fitGP1d(theta, g, hyp1, hyp2, gvar=None, hypstarts=None, hypinds=None,
     else:
         subinfo['hyp'] = hypn
         subinfo['hypind'] = -1
-        subinfo['hypcov'] = subinfo['hyp'][:-1]
+        subinfo['hypcov'] = subinfo['hyp'][:-2]
+        subinfo['hypvarconst'] = subinfo['hyp'][-2]
         subinfo['nug'] = np.exp(subinfo['hyp'][-1]) / (1 + np.exp(subinfo['hyp'][-1]))
 
         R = __covmat(theta, theta, subinfo['hypcov'])
         subinfo['R'] = (1 - subinfo['nug']) * R + subinfo['nug'] * np.eye(R.shape[0])
         if gvar is not None:
-            subinfo['R'] += np.diag(gvar)
+            subinfo['R'] += np.exp(subinfo['hypvarconst'])*np.diag(gvar)
         n = subinfo['R'].shape[0]
         W, V = np.linalg.eigh(subinfo['R'])
         Vh = V / np.sqrt(np.abs(W))
@@ -759,18 +789,20 @@ def __fitGP1d(theta, g, hyp1, hyp2, gvar=None, hypstarts=None, hypinds=None,
 
 def __negloglik(hyp, info):
     """Return penalized log likelihood of single demensional GP model."""
-    R0 = __covmat(info['theta'], info['theta'], hyp[:-1])
+    R0 = __covmat(info['theta'], info['theta'], hyp[:-2])
     nug = np.exp(hyp[-1]) / (1 + np.exp(hyp[-1]))
     R = (1 - nug) * R0 + nug * np.eye(info['theta'].shape[0])
+
     if info['gvar'] is not None:
-        R += np.diag(info['gvar'])
+        R += np.exp(hyp[-2])*np.diag(info['gvar'])
     W, V = np.linalg.eigh(R)
     Vh = V / np.sqrt(np.abs(W))
     fcenter = Vh.T @ info['g']
     n = info['g'].shape[0]
-    sig2hat = (n * np.mean(fcenter ** 2) + 10) / (n + 10)
+
+    sig2hat = (n * np.mean(fcenter ** 2) + np.exp(hyp[-2])) / (n + np.exp(hyp[-2]))
     negloglik = 1 / 2 * np.sum(np.log(np.abs(W))) + 1 / 2 * n * np.log(sig2hat)
-    negloglik += 0.5 * np.sum((((10 ** (-8) + hyp - info['hypregmean'])) /
+    negloglik += 0.5 * np.sum(((10 ** (-8) + hyp - info['hypregmean']) /
                                (info['hypregstd'])) ** 2)
     return negloglik
 
@@ -778,27 +810,32 @@ def __negloglik(hyp, info):
 def __negloglikgrad(hyp, info):
     """Return gradient of the penalized log likelihood of single demensional
     GP model."""
-    R0, dR = __covmat(info['theta'], info['theta'], hyp[:-1], True)
+    R0, dR = __covmat(info['theta'], info['theta'], hyp[:-2], True)
     nug = np.exp(hyp[-1]) / (1 + np.exp(hyp[-1]))
     R = (1 - nug) * R0 + nug * np.eye(info['theta'].shape[0])
-    if info['gvar'] is not None:
-        R += np.diag(info['gvar'])
-
     dR = (1 - nug) * dR
-    dRappend = nug / ((1 + np.exp(hyp[-1]))) * (-R0 + np.eye(info['theta'].shape[0]))
-    dR = np.append(dR, dRappend[:, :, None], axis=2)
+    dRappend2 = nug / (1 + np.exp(hyp[-1])) * (-R0 + np.eye(info['theta'].shape[0]))
+
+    if info['gvar'] is not None:
+        R += np.exp(hyp[-2]) * np.diag(info['gvar'])
+        dRappend1 = np.exp(hyp[-2]) * np.diag(info['gvar'])
+    else:
+        dRappend1 = 0 * np.eye(info['theta'].shape[0])
+
+    dR = np.append(dR, dRappend1[:, :, None], axis=2)
+    dR = np.append(dR, dRappend2[:, :, None], axis=2)
     W, V = np.linalg.eigh(R)
     Vh = V / np.sqrt(np.abs(W))
     fcenter = Vh.T @ info['g']
     n = info['g'].shape[0]
-    sig2hat = (n * np.mean(fcenter ** 2) + 10) / (n + 10)
+    sig2hat = (n * np.mean(fcenter ** 2) + np.exp(hyp[-2])) / (n + np.exp(hyp[-2]))
     dnegloglik = np.zeros(dR.shape[2])
     Rinv = Vh @ Vh.T
 
     for k in range(0, dR.shape[2]):
         dsig2hat = - np.sum((Vh @
                              np.multiply.outer(fcenter, fcenter) @
-                             Vh.T) * dR[:, :, k]) / (n + 10)
+                             Vh.T) * dR[:, :, k]) / (n + np.exp(hyp[-2]))
         dnegloglik[k] += 0.5 * n * dsig2hat / sig2hat
         dnegloglik[k] += 0.5 * np.sum(Rinv * dR[:, :, k])
 

--- a/surmise/emulationmethods/PCGPwM.py
+++ b/surmise/emulationmethods/PCGPwM.py
@@ -1,8 +1,5 @@
 """PCGPwM method - PCGP with Missingness, an extension to PCGP
-(Higdon et al., 2008). In addition, the PCGPwM method provides the functionality
-to suggest selections of next parameters and obviations of any parameters on
-a list.  Obviation refers to the stopping of value retrieval of `f` for a
-parameter."""
+(Higdon et al., 2008). """
 
 import numpy as np
 import scipy.optimize as spo
@@ -12,7 +9,7 @@ from surmise.emulationsupport.matern_covmat import covmat as __covmat
 
 
 def fit(fitinfo, x, theta, f, epsilonPC=0.001, epsilonImpute=10e-6,
-        lognugmean=-10, lognugLB=-20, varconstant=None, dampalpha=0.3, bigM=10,
+        lognugmean=-10, lognugLB=-20, varconstant=None, dampalpha=0.3, eta=10,
         standardpcinfo=None, verbose=0, **kwargs):
     '''
     The purpose of fit is to take information and plug all of our fit
@@ -62,6 +59,8 @@ def fit(fitinfo, x, theta, f, epsilonPC=0.001, epsilonImpute=10e-6,
         A parameter to control the rate of increase of variance as amount of missing
         values increases.  Default is 0.3, otherwise an appropriate range is (0, 0.5).
         Values larger than 0.5 are permitted but it leads to poor empirical performance.
+    eta : scalar
+        A parameter as an upper bound for the additional variance term.  Default is 10.
     standardpcinfo : dict
         A dictionary user supplies that contains information for standardization of `f`,
         in the following format, such that fs = (f - offset) / scale, U are the
@@ -104,7 +103,7 @@ def fit(fitinfo, x, theta, f, epsilonPC=0.001, epsilonImpute=10e-6,
     hypvarconst = np.log(varconstant) if varconstant is not None else None
 
     fitinfo['dampalpha'] = dampalpha
-    fitinfo['bigM'] = bigM
+    fitinfo['eta'] = eta
 
     fitinfo['theta'] = theta
     fitinfo['f'] = f
@@ -689,7 +688,7 @@ def __fitGPs(fitinfo, theta, numpcs, hyp1, hyp2, varconstant):
                                             hypvarconst=varconstant,
                                             gvar=fitinfo['unscaled_pcstdvar'][:, pcanum],
                                             dampalpha=fitinfo['dampalpha'],
-                                            bigM=fitinfo['bigM'],
+                                            eta=fitinfo['eta'],
                                             hypstarts=hypstarts[hypwhere, :],
                                             hypinds=hypwhere,
                                             sig2ofconst=0.01)
@@ -701,7 +700,7 @@ def __fitGPs(fitinfo, theta, numpcs, hyp1, hyp2, varconstant):
                                             hypvarconst=varconstant,
                                             gvar=fitinfo['unscaled_pcstdvar'][:, pcanum],
                                             dampalpha=fitinfo['dampalpha'],
-                                            bigM=fitinfo['bigM'],
+                                            eta=fitinfo['eta'],
                                             sig2ofconst=0.01)
                 hypstarts = np.zeros((numpcs, emulist[pcanum]['hyp'].shape[0]))
             emulist[pcanum]['hypind'] = min(pcanum, emulist[pcanum]['hypind'])
@@ -712,7 +711,7 @@ def __fitGPs(fitinfo, theta, numpcs, hyp1, hyp2, varconstant):
     return emulist
 
 
-def __fitGP1d(theta, g, hyp1, hyp2, hypvarconst, gvar=None, dampalpha=None, bigM=None,
+def __fitGP1d(theta, g, hyp1, hyp2, hypvarconst, gvar=None, dampalpha=None, eta=None,
               hypstarts=None, hypinds=None, sig2ofconst=None):
     """Return a fitted model from the emulator model using smart method."""
     hypvarconstmean = 4 if hypvarconst is None else hypvarconst
@@ -742,7 +741,7 @@ def __fitGP1d(theta, g, hyp1, hyp2, hypvarconst, gvar=None, dampalpha=None, bigM
     # maxgvar = np.max(gvar)
     # gvar = gvar / ((np.abs(maxgvar*1.001 - gvar)) ** dampalpha)
 
-    gvar = np.minimum(bigM, gvar / ((1 - gvar)**dampalpha))
+    gvar = np.minimum(eta, gvar / ((1 - gvar)**dampalpha))
 
     subinfo['sig2ofconst'] = sig2ofconst
     subinfo['gvar'] = gvar[thetac]

--- a/surmise/emulationmethods/PCGPwM.py
+++ b/surmise/emulationmethods/PCGPwM.py
@@ -58,7 +58,7 @@ def fit(fitinfo, x, theta, f, epsilon=0.1, lognugmean=-10,
     dampalpha : scalar
         A parameter to control the rate of increase of variance as amount of missing
         values increases.  Default is 0.3, otherwise an appropriate range is (0, 0.5).
-        Values larger than 0.5 are permitted but it leads to poor empirical performance. 
+        Values larger than 0.5 are permitted but it leads to poor empirical performance.
     verbose : scalar
         A parameter to suppress in-method console output.  Use 0 to suppress output,
         use 1 to show output.

--- a/surmise/emulationmethods/PCGPwMatComp.py
+++ b/surmise/emulationmethods/PCGPwMatComp.py
@@ -7,6 +7,7 @@ import numpy as np
 import surmise.emulationmethods.PCGPwM as semPCGPwM
 try:
     from sklearn.experimental import enable_iterative_imputer
+    tmpload = enable_iterative_imputer.IterativeImputer
     from sklearn.impute import IterativeImputer
     from sklearn.linear_model import BayesianRidge
     from sklearn.neighbors import KNeighborsRegressor


### PR DESCRIPTION
Updates to PCGPwM:

- Introduced parameters to control magnitude of imputation variances
- Introduced parameters to adjust nugget that ensures non-singularity of covariance matrix for imputation
- Now allows user input principal component information for imputation 

Updates to PCGPwImpute (formerly PCGPwMatComp)

- **Dependencies:** Requires scikit-learn `sklearn` package.
- Renamed to PCGPwImpute to reflect the use of scikit-learn IterativeImputer functionality
- Matrix completion methods are replaced with other classes of imputation methods to ensure stability.
- Simplified function arguments to reflect dependence.