### PR TITLE
Warnings to be shown unless deliberately ignored

### DIFF
--- a/surmise/calibration.py
+++ b/surmise/calibration.py
@@ -92,10 +92,11 @@ class calibrator(object):
 
         '''
 
-        if ('warnings' in args.keys()) and args['warnings']:
-            warnings.resetwarnings()
-        else:
+        # default to showing all warnings
+        if ('warnings' in args.keys()) and ~args['warnings']:
             warnings.simplefilter('ignore')
+        else:
+            warnings.resetwarnings()
 
         self.args = args
         if y is None:

--- a/surmise/emulation.py
+++ b/surmise/emulation.py
@@ -77,10 +77,11 @@ class emulator(object):
 
         '''
 
-        if ('warnings' in args.keys()) and args['warnings']:
-            warnings.resetwarnings()
-        else:
+        # default to showing all warnings
+        if ('warnings' in args.keys()) and ~args['warnings']:
             warnings.simplefilter('ignore')
+        else:
+            warnings.resetwarnings()
 
         self.__ptf = passthroughfunc
         self.__f = None


### PR DESCRIPTION
Currently the default is to ignore any warnings.  It hides code feedback and makes debugging with surmise harder.  

This pull request is to make warnings not ignored by default, but still allow user input to suppress warnings.