### PR TITLE
Set two calibration methods as research grade

### DIFF
--- a/src/surmise/calibration.py
+++ b/src/surmise/calibration.py
@@ -98,6 +98,17 @@ class calibrator(object):
         None.
 
         '''
+        # Calibrators that could be loaded, but that are research-grade only and
+        # should not be offered through the public interface.
+        #
+        # TODO: This should be removed as part of refactoring the calibrator
+        # portion of the public interface.
+        RESEARCH_CALS = ["mlbayeswoodbury", "simulationpost"]
+        if method.lower() in RESEARCH_CALS:
+            if ("expertMode" not in args.keys()) or (not args["expertMode"]):
+                msg = "{} is included for unofficial research purposes only"
+                raise ValueError(msg.format(method))
+
         # cast to numpy.float64, currently only for theta and f.
         if y is not None:
             y = cast_f64_dtype(y)

--- a/src/surmise/tests/test_new_cal.py
+++ b/src/surmise/tests/test_new_cal.py
@@ -69,7 +69,7 @@ def does_not_raise():
     [
      ('directbayes', does_not_raise()),
      ('directbayeswoodbury', does_not_raise()),
-     ('mlbayeswoodbury', does_not_raise())
+     # ('mlbayeswoodbury', does_not_raise())
     ],
     )
 # tests for prediction class methods:
@@ -92,7 +92,7 @@ def test_prediction_mean(cmdopt2, expectation):
     [
      ('directbayes', does_not_raise()),
      ('directbayeswoodbury', does_not_raise()),
-     ('mlbayeswoodbury', does_not_raise())
+     # ('mlbayeswoodbury', does_not_raise())
     ],
     )
 # test to check the prediction.var()
@@ -114,7 +114,7 @@ def test_prediction_var(cmdopt2, expectation):
     [
      ('directbayes', does_not_raise()),
      ('directbayeswoodbury', does_not_raise()),
-     ('mlbayeswoodbury', does_not_raise())
+     # ('mlbayeswoodbury', does_not_raise())
     ],
     )
 # test to check the prediction.rnd()
@@ -136,7 +136,7 @@ def test_prediction_rnd(cmdopt2, expectation):
     [
      ('directbayes', pytest.raises(ValueError)),
      ('directbayeswoodbury', pytest.raises(ValueError)),
-     ('mlbayeswoodbury', pytest.raises(ValueError))
+     # ('mlbayeswoodbury', pytest.raises(ValueError))
     ],
     )
 # test to check the prediction.lpdf()
@@ -158,7 +158,7 @@ def test_prediction_lpdf(cmdopt2, expectation):
     [
      ('directbayes', does_not_raise()),
      ('directbayeswoodbury', does_not_raise()),
-     ('mlbayeswoodbury', does_not_raise())
+     # ('mlbayeswoodbury', does_not_raise())
     ],
     )
 # test to check the theta.mean()
@@ -179,7 +179,7 @@ def test_prediction_thetamean(cmdopt2, expectation):
     [
      ('directbayes', does_not_raise()),
      ('directbayeswoodbury', does_not_raise()),
-     ('mlbayeswoodbury', does_not_raise())
+     # ('mlbayeswoodbury', does_not_raise())
     ],
     )
 # test to check the theta.var()
@@ -200,7 +200,7 @@ def test_prediction_thetavar(cmdopt2, expectation):
     [
      ('directbayes', does_not_raise()),
      ('directbayeswoodbury', does_not_raise()),
-     ('mlbayeswoodbury', does_not_raise())
+     # ('mlbayeswoodbury', does_not_raise())
     ],
     )
 # test to check the theta.rnd()
@@ -221,7 +221,7 @@ def test_prediction_thetarnd(cmdopt2, expectation):
     [
      ('directbayes', does_not_raise()),
      ('directbayeswoodbury', does_not_raise()),
-     ('mlbayeswoodbury', does_not_raise())
+     # ('mlbayeswoodbury', does_not_raise())
     ],
     )
 # test to check the theta.lpdf()


### PR DESCRIPTION
PR self-review

- [x] Review all changes carefully
  * `test_new_cal` was checked out from `166ExpandTestSuite` to simplify merging of these two branches
- [x] Confirm that all tox tasks passing locally
- [x] Manually confirm that non-research-grade calibration methods can be used regardless of `expertMode` usage
- [x] Manually confirm that research-grade calibration methods cannot be used in absence of `expertMode` or with this flag set to `False`
- [x] Manually confirm that research-grade calibration methods can be used when `expertMode` is set to `True`
- [x] Confirm that all actions are passing