### PR TITLE
Designate LMC sampler as research grade

### DIFF
--- a/src/surmise/calibration.py
+++ b/src/surmise/calibration.py
@@ -108,6 +108,16 @@ class calibrator(object):
             if ("expertMode" not in args.keys()) or (not args["expertMode"]):
                 msg = "{} is included for unofficial research purposes only"
                 raise ValueError(msg.format(method))
+            else:
+                # With the current implementation, expertMode=True could be
+                # added to the calibration arguments with the intent of using a
+                # research-grade calibrator but unintentionally allowing the use
+                # of a research-grade sampler (or vice versa).  Refactorings
+                # will hopefully avoid this ambiguity.
+                #
+                # Emit warning to extend a helping hand to the experts.
+                msg = f"Using unofficial research {method} calibrator"
+                warnings.warn(msg)
 
         # cast to numpy.float64, currently only for theta and f.
         if y is not None:

--- a/src/surmise/utilities.py
+++ b/src/surmise/utilities.py
@@ -1,3 +1,4 @@
+import warnings
 import importlib
 
 
@@ -59,6 +60,29 @@ class sampler(object):
         None.
 
         '''
+        # Samplers that could be loaded, but that are research-grade only and
+        # should not be offered through the public interface.
+        #
+        # TODO: This should be removed as part of refactoring the sampler
+        # portion of the public interface (Issue #159).
+        KEY = "expertMode"
+        RESEARCH_SAMPLERS = ["lmc"]
+
+        if sampler.lower() in RESEARCH_SAMPLERS:
+            if (KEY not in self.options) or (not self.options[KEY]):
+                msg = "{} is included for unofficial research purposes only"
+                raise ValueError(msg.format(sampler))
+            else:
+                # With the current implementation, expertMode=True could be
+                # added to the calibration arguments with the intent of using a
+                # research-grade calibrator but unintentionally allowing the use
+                # of a research-grade sampler (or vice versa).  The refactoring
+                # will hopefully avoid this ambiguity.
+                #
+                # Emit warning to extend a helping hand to the experts.
+                msg = f"Using unofficial research {sampler} sampler"
+                warnings.warn(msg)
+
         self.method = importlib.import_module('surmise.utilitiesmethods.'
                                               + sampler)
 


### PR DESCRIPTION
PR self-review

- [x] Review all changes carefully
- [x] Manually confirm that non-research-grade samplers can be used regardless of `expertMode` usage and that no warnings are emitted
- [x] Manually confirm that LMC cannot be used in absence of `expertMode` or with this flag set to `False` and that no warnings are emitted
- [x] Manually confirm that LMC can be used when `expertMode` is set to `True` and the expected warning is emitted
- [x] Manually confirm that the expected warning is emitted when `expertMode` is set to `True` when using a research-grade calibrator both with and without LMC.  In the former case, confirm that both warnings are emitted.
- [x] Confirm that all actions are passing
  * Slight decrease in coverage-by-line is as expected