### PR TITLE
Set PCGPR to research grade emulator

### DIFF
--- a/src/surmise/emulation.py
+++ b/src/surmise/emulation.py
@@ -77,6 +77,21 @@ class emulator(object):
         None.
 
         '''
+        # Emulators that could be loaded but that are research-grade only and
+        # should not be offered through the public interface.
+        #
+        # TODO: This should be removed as part of refactoring the emulator
+        # portion of the public interface.
+        RESEARCH_EMUS = ["pcgpr"]
+        if method.lower() in RESEARCH_EMUS:
+            if ("expertMode" not in args.keys()) or (not args["expertMode"]):
+                msg = "{} is included for unofficial research purposes only"
+                raise ValueError(msg.format(method))
+            else:
+                # Emit warning to extend a helping hand to the experts.
+                msg = f"Using unofficial research {method} emulator"
+                warnings.warn(msg)
+
         # cast to numpy.float64, currently only for theta and f.
         if theta is not None:
             theta = cast_f64_dtype(theta)


### PR DESCRIPTION
PR self-review

- [x] Review all changes carefully
- [x] Manually confirm that non-research-grade emulators can be used regardless of `expertMode` usage and that no warnings are emitted
- [x] Manually confirm that PCGPR cannot be used in absence of `expertMode` or with this flag set to `False` and that no warnings are emitted
- [x] Manually confirm that PCGPR can be used when `expertMode` is set to `True` and the expected warning is emitted
- [x] Confirm that all actions are passing
- [x] Confirm that `main` has not changed

It is acceptable that code-coverage-by-line decreases since PCGPR is not being tested and therefore the test suite is not executing, for example, raising either the error or the warning.