### PR TITLE
Improve use of numpy arrays in 1D.

### DIFF
--- a/tools/AbstractDistribution.py
+++ b/tools/AbstractDistribution.py
@@ -27,11 +27,8 @@ class AbstractDistribution(metaclass=abc.ABCMeta):
         checked = np.atleast_2d(np.squeeze(np.asarray_chkfinite(theta)))
         if not all(np.isreal(checked.flatten())):
             raise ValueError("theta values are not real")
-
         if self.dimension == 1:
             checked = checked.T
-            assert checked.shape[1] == 1
-            return checked
 
         if checked.ndim != 2:
             raise ValueError("theta must be 2D array")

--- a/tools/AbstractDistribution.py
+++ b/tools/AbstractDistribution.py
@@ -7,20 +7,33 @@ class AbstractDistribution(metaclass=abc.ABCMeta):
     def __init__(self):
         pass
 
+    def _as1darray_checked(self, x):
+        """
+        :return: real, finite 1d numpy array
+        """
+        checked = np.atleast_1d(np.squeeze(np.asarray_chkfinite(x)))
+        if not all(np.isreal(checked.flatten())):
+            raise ValueError("x values are not real")
+        if checked.ndim != 1:
+            raise ValueError("x must be 1D array")
+
+        return checked
+
     def _as2darray_checked(self, theta):
         """
         :return: real, finite 2d numpy array where rows correspond to theta
             points; columns, to theta coordinates.
         """
-        checked = np.squeeze(np.asarray_chkfinite(theta))
+        checked = np.atleast_2d(np.squeeze(np.asarray_chkfinite(theta)))
         if not all(np.isreal(checked.flatten())):
             raise ValueError("theta values are not real")
 
         if self.dimension == 1:
-            checked = np.atleast_2d(checked).T
+            checked = checked.T
             assert checked.shape[1] == 1
             return checked
-        elif checked.ndim != 2:
+
+        if checked.ndim != 2:
             raise ValueError("theta must be 2D array")
         elif checked.shape[1] != self.dimension:
             raise ValueError("theta array has invalid shape")
@@ -50,7 +63,6 @@ class AbstractDistribution(metaclass=abc.ABCMeta):
         :param p: 1D numpy array of probability values, must be between 0 and 1.
         :return: 1D numpy array of quantile values of the distribution.
         """
-
         raise NotImplementedError("Inverse cdf inv_cdf is not implemented.")
 
     @abc.abstractmethod

--- a/tools/NormalDistribution.py
+++ b/tools/NormalDistribution.py
@@ -33,15 +33,21 @@ class NormalDistribution(AbstractDistribution):
         return self.__N.stats("mv")
 
     def inv_cdf(self, p):
-        return self.__N.ppf(self._as2darray_checked(p))
+        values = self.__N.ppf(self._as1darray_checked(p))
+        assert values.ndim == 1
+        return values
 
     def pdf(self, theta):
-        return self.__N.pdf(self._as2darray_checked(theta))
+        values = self.__N.pdf(self._as1darray_checked(theta))
+        assert values.ndim == 1
+        return values
 
     def logpdf(self, theta, return_grad):
         if return_grad:
             raise NotImplementedError("gradient not implemented yet")
-        return self.__N.logpdf(self._as2darray_checked(theta))
+        values = self.__N.logpdf(self._as1darray_checked(theta))
+        assert values.ndim == 1
+        return values
 
     def sample(self, n, rng):
         samples = np.atleast_2d(self.__N.rvs(size=n, random_state=rng))

--- a/tools/TestSampler.py
+++ b/tools/TestSampler.py
@@ -84,14 +84,12 @@ class TestSampler(unittest.TestCase):
         # ----  "HARDCODED"
         FNAME_H5 = self.__dir.joinpath(f"{name}.h5")
 
+        QUANTILES_PROBS = np.array([0.01, 0.05, 0.1, 0.25,
+                                    0.5, 0.75, 0.9, 0.95, 0.99])
+
         # ----- TRUE MOMENTS
         dimension = target_distribution.dimension
         mu_true, var_true = target_distribution.moments
-
-        # ----- TRUE QUANTILES
-        quantiles_probs = np.array([0.01, 0.05, 0.1, 0.25,
-                                    0.5, 0.75, 0.9, 0.95, 0.99])
-        quantiles_true = target_distribution.inv_cdf(quantiles_probs)
 
         # ----- MCMC CONFIGURATION
         # -- Universal Configuration
@@ -179,12 +177,12 @@ class TestSampler(unittest.TestCase):
 
         # -- Compute integrated quantities & log
         if dimension == 1:
+            quantiles_true = target_distribution.inv_cdf(QUANTILES_PROBS)
             samples_rmse = np.sqrt(np.mean((samples - mu_true)**2))
-            quantiles_results = np.atleast_2d(
-                np.quantile(samples, quantiles_probs)).T
+            quantiles_results = np.quantile(samples, QUANTILES_PROBS)
             quantiles_absdiff = np.abs(quantiles_true - quantiles_results)
             table_quantiles = np.column_stack(
-                (np.atleast_2d(quantiles_probs).T,
+                (QUANTILES_PROBS,
                  quantiles_true, quantiles_results,
                  quantiles_absdiff))
             print(f'Number of samples: {n_samples} \t '

--- a/tools/UniformDistribution.py
+++ b/tools/UniformDistribution.py
@@ -38,15 +38,21 @@ class UniformDistribution(AbstractDistribution):
         return self.__U.stats("mv")
 
     def inv_cdf(self, p):
-        return self.__U.ppf(self._as2darray_checked(p))
+        values = self.__U.ppf(self._as1darray_checked(p))
+        assert values.ndim == 1
+        return values
 
     def pdf(self, theta):
-        return self.__U.pdf(self._as2darray_checked(theta))
+        values = self.__U.pdf(self._as1darray_checked(theta))
+        assert values.ndim == 1
+        return values
 
     def logpdf(self, theta, return_grad):
         if return_grad:
             raise NotImplementedError("gradient not implemented yet")
-        return self.__U.logpdf(self._as2darray_checked(theta))
+        values = self.__U.logpdf(self._as1darray_checked(theta))
+        assert values.ndim == 1
+        return values
 
     def sample(self, n, rng):
         samples = np.atleast_2d(self.__U.rvs(size=n, random_state=rng))


### PR DESCRIPTION
This brings 1D derived distribution classes into agreement with `AbstractDistribution` inline documentation interface contracts.

PR Self-review

- [x] Review all changes made
- [x] Run tool on current test suite and review output of Normal 1D test
- [x] Confirm all actions passing