### PR TITLE
First evaluation must yield positive density

### DIFF
--- a/src/surmise/utilitiesmethods/metropolis_hastings.py
+++ b/src/surmise/utilitiesmethods/metropolis_hastings.py
@@ -73,15 +73,17 @@ def sampler(logpost_func,
         theta0 = draw_func(1)
 
     p = theta0.shape[1]
-    lposterior = np.zeros(burnSamples + numsamp)
-    theta = np.zeros((burnSamples + numsamp, theta0.shape[1]))
-    # print(theta0)
-    lposterior[0] = logpost_func(theta0, return_grad=False).item()
+    theta = np.full((burnSamples + numsamp, p), np.nan, float)
     theta[0] = theta0
+
+    lposterior = np.full(burnSamples + numsamp, np.nan, float)
+    lposterior[0] = np.squeeze(logpost_func(theta0, return_grad=False))
+    if not np.isfinite(lposterior[0]):
+        assert lposterior[0] == -np.inf
+        raise RuntimeError("Initial theta evaluates to zero density")
+
     n_acc = 0
-
     lposterior_list = []
-
     for i in range(1, burnSamples + numsamp):
         if verbose:
             if i % 30000 == 0:
@@ -95,7 +97,7 @@ def sampler(logpost_func,
         theta_cand = np.reshape(np.array(theta_cand), (1, p))
 
         # Compute loglikelihood
-        logpost = logpost_func(theta_cand, return_grad=False).item()
+        logpost = np.squeeze(logpost_func(theta_cand, return_grad=False))
 
         if logpost == -np.inf:
             accept = False

--- a/tools/MetropolisHastingsTestSuite.json
+++ b/tools/MetropolisHastingsTestSuite.json
@@ -19,7 +19,7 @@
                     "Scale":  2.5
                 },
                 "SampleSkip":         10,
-                "Plot":            true,
+                "Plot":            false,
                 "Benchmark":          "MH_Uniform1D_NormalStep.benchmark",
                 "n_burn_samples":  10000,
                 "n_samples":      100000,
@@ -39,7 +39,7 @@
                     "Scale":  6.0
                 },
                 "SampleSkip":         10,
-                "Plot":            true,
+                "Plot":            false,
                 "Benchmark":          "MH_Uniform1D_UniformStep.benchmark",
                 "n_burn_samples":  10000,
                 "n_samples":      100000,
@@ -70,7 +70,7 @@
                 },
                 "SampleSkip":         10,
                 "Benchmark":           "MH_Uniform2D_NormalStep.benchmark",
-                "Plot":             true,
+                "Plot":             false,
                 "CornerPlotBins":      30,
                 "n_burn_samples":    1000,
                 "n_samples":       100000,
@@ -100,7 +100,7 @@
                     "Scale":  3.5
                 },
                 "SampleSkip":         10,
-                "Plot":            true,
+                "Plot":            false,
                 "Benchmark":          "MH_Normal1D_NormalStep.benchmark",
                 "n_burn_samples":  10000,
                 "n_samples":      100000,
@@ -121,7 +121,7 @@
                     "Scale":  10.0
                 },
                 "SampleSkip":         10,
-                "Plot":            true,
+                "Plot":            false,
                 "Benchmark":          "MH_Normal1D_UniformStep.benchmark",
                 "n_burn_samples":  10000,
                 "n_samples":      100000,
@@ -153,7 +153,7 @@
                     "Scale":      [1.0, 5.0]
                 },
                 "SampleSkip":         20,
-                "Plot":            true,
+                "Plot":            false,
                 "Benchmark":          "MH_Normal2D_NormalStep.benchmark",
                 "CornerPlotBins":     50,
                 "n_burn_samples":  10000,
@@ -188,7 +188,7 @@
                     "Scale":      [1.0, 5.0, 0.2]
                 },
                 "SampleSkip":         20,
-                "Plot":            true,
+                "Plot":            false,
                 "Benchmark":          "MH_Normal3D_NormalStep.benchmark",
                 "CornerPlotBins":     50,
                 "n_burn_samples":  10000,
@@ -223,7 +223,7 @@
                     "Scale": [1.0, 1.75, 2.5, 0.2]
                 },
                 "SampleSkip":          20,
-                "Plot":             true,
+                "Plot":             false,
                 "Benchmark":           "MH_Uniform4D_UniformStep.benchmark",
                 "CornerPlotBins":      25,
                 "n_burn_samples":   10000,

--- a/tools/MetropolisHastingsTestSuite.json
+++ b/tools/MetropolisHastingsTestSuite.json
@@ -62,7 +62,7 @@
                 "StartDistribution": {
                     "Name":      "Uniform",
                     "Intervals": [[-0.5, 0.5],
-                                  [0.0, 1.0]]
+                                  [ 1.5, 2.1]]
                 },
                 "StepDistribution": {
                     "Name":       "normal",
@@ -70,7 +70,7 @@
                 },
                 "SampleSkip":         10,
                 "Benchmark":           "MH_Uniform2D_NormalStep.benchmark",
-                "Plot":             false,
+                "Plot":              true,
                 "CornerPlotBins":      30,
                 "n_burn_samples":    1000,
                 "n_samples":       100000,


### PR DESCRIPTION
This is a second try at #218, whose commits were built up before the fix brought into `main` by #219.  I started a new branch off of the resultant merge commit so that I could see the desired sequence of failures and fixes including the 219 fix.

Please see the git commit messages for more information

PR Self-review

- [x] Review all changes
- [x] Create and verify new benchmark for test that was fixed on branch
- [x] Checkout commit eca9f8c02 and confirm that error is caught and failure reported as expected
- [x] Reset to latest commit on this branch and confirm that test script's suite is passing again
- [x] Run `nocoverage` task locally and confirm no new warnings
- [x] Confirm all actions passing