### PR TITLE
Fix MH logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def readme_rst():
 
 python_requires = ">=3.10"
 code_requires = [
-    'numpy>=1.22.0',
+    'numpy>=1.22.0,<2.5.0',
     'scipy>=1.9.0',
     'scikit-learn>=1.2.0',
     'dill>=0.3.8'

--- a/src/surmise/utilitiesmethods/metropolis_hastings.py
+++ b/src/surmise/utilitiesmethods/metropolis_hastings.py
@@ -39,6 +39,9 @@ def sampler(logpost_func,
         returns numsamp random draws from posterior.
 
     '''
+    # Hardcoded values
+    LOG_RATE = 25_000
+
     # random number generator
     # TODO: This is an intermediate step.  Eventually calling code should be
     # forced to provide an RNG.
@@ -82,13 +85,12 @@ def sampler(logpost_func,
         assert lposterior[0] == -np.inf
         raise RuntimeError("Initial theta evaluates to zero density")
 
-    n_acc = 0
+    # We implicitly treat theta0 as accepted.  If the number of burn-in samples
+    # is positive, we also treat it as part of the burn-in.
+    n_acc = 1 if burnSamples == 0 else 0
+    n_official_i = 1 if burnSamples == 0 else 0
     lposterior_list = []
     for i in range(1, burnSamples + numsamp):
-        if verbose:
-            if i % 30000 == 0:
-                print("At sample {}, acceptance rate is {}.".format(i, n_acc/i))
-
         # Candidate theta
         step = step_distribution.rvs(size=p, random_state=rng)
         theta_cand = theta[i-1, :] + stepParam * step
@@ -138,9 +140,24 @@ def sampler(logpost_func,
             lposterior[i] = lposterior[i-1]
             lposterior_list.append(logpost)
 
+        # N official samples completed by end of i^th iteration
+        # - Nonpositive value indicates still in warm-up phase
+        n_official_i = i - burnSamples + 1
+
+        if verbose:
+            if (n_official_i >= 1) and (n_official_i % LOG_RATE == 0):
+                acc_rate = n_acc / float(n_official_i)
+                assert 0.0 <= acc_rate <= 1.0
+                print(
+                    f"Sample {n_official_i:>10} acceptance rate={acc_rate}"
+                )
+    assert n_official_i == numsamp
+    acc_rate = n_acc / float(numsamp)
+    assert 0.0 <= acc_rate <= 1.0
+
     theta = theta[(burnSamples):(burnSamples + numsamp), :]
-    sampler_info = {'theta': theta, 'acc_rate': n_acc/numsamp,
+    sampler_info = {'theta': theta, 'acc_rate': acc_rate,
                     'lpostlist': np.array(lposterior_list)}
     if verbose:
-        print("Final Acceptance Rate: ", n_acc/numsamp)
+        print("Final Acceptance Rate: ", sampler_info["acc_rate"])
     return sampler_info

--- a/tools/MetropolisHastingsTestSuite.json
+++ b/tools/MetropolisHastingsTestSuite.json
@@ -70,7 +70,7 @@
                 },
                 "SampleSkip":         10,
                 "Benchmark":           "MH_Uniform2D_NormalStep.benchmark",
-                "Plot":              true,
+                "Plot":             false,
                 "CornerPlotBins":      30,
                 "n_burn_samples":    1000,
                 "n_samples":       100000,


### PR DESCRIPTION
Note that the first commit in this branch also limits the version of installed `numpy` to less than the newest version `v2.5.0`, which was apparently just released and is causing problems (Issue #221).

PR Self-review

- [x] Review all changes made here
- [x] Run test script locally before the fix was made to confirm existence of logging bug
   * For the `Uniform4D` test, set the N burn-in to 100,000
- [x] Run test script locally on the latest commit on this branch to confirm correct logging.  This changes should **not** alter the final results nor the values stored into test script results.  Therefore, we should expect bitwise identical results.
- [x] Confirm all actions passing

Before making the change, the logging output for the altered `Uniform4D`test is
```
Sampling ...		At sample 30000, acceptance rate is 0.0.
At sample 60000, acceptance rate is 0.0.
At sample 90000, acceptance rate is 0.0.
At sample 120000, acceptance rate is 0.05308333333333334.
At sample 150000, acceptance rate is 0.10749333333333333.
At sample 180000, acceptance rate is 0.14374444444444445.
At sample 210000, acceptance rate is 0.16934761904761905.
At sample 240000, acceptance rate is 0.18830833333333333.
At sample 270000, acceptance rate is 0.20312222222222223.
At sample 300000, acceptance rate is 0.21483.
At sample 330000, acceptance rate is 0.2245939393939394.
Final Acceptance Rate:  0.322152
done
```
which is clearly wrong since
* it's logging acceptance rates during the warm-up phase (but correctly reported as zero),
* the total number of samples logged (>330,000) exceeds the number of official samples requested by the user (250,000),
* acceptance rates reported after the warm-up phase are unexpectedly small since the rates are computed using the total number of warm-up and official iterations, and
* we see the clear jump in rate to the true acceptance rate after MCMC sampling has finished.

With this change, I see
```
Sampling ...		Sample      25000 acceptance rate=0.322
Sample      50000 acceptance rate=0.3231
Sample      75000 acceptance rate=0.32033333333333336
Sample     100000 acceptance rate=0.31953
Sample     125000 acceptance rate=0.320064
Sample     150000 acceptance rate=0.3204266666666667
Sample     175000 acceptance rate=0.3212514285714286
Sample     200000 acceptance rate=0.32172
Sample     225000 acceptance rate=0.3216311111111111
Sample     250000 acceptance rate=0.321564
Final Acceptance Rate:  0.321564
```
noting that
* the total N official samples equals the requested number,
* the final rate equals the rate reported at 250,000 samples (as expected since the logging rate is a multiple of the total N iterations requested),
* and the rate does not change substantially throughout the run.