### PR TITLE
Ensure that real eigenvalues and eigenvectors are returned

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def readme_rst():
 
 python_requires = ">=3.10"
 code_requires = [
-    'numpy>=1.22.0,<2.5.0',
+    'numpy>=2.5.0',
     'scipy>=1.9.0',
     'scikit-learn>=1.2.0',
     'dill>=0.3.8'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def readme_rst():
 
 python_requires = ">=3.10"
 code_requires = [
-    'numpy>=2.5.0',
+    'numpy>=1.22.0',
     'scipy>=1.9.0',
     'scikit-learn>=1.2.0',
     'dill>=0.3.8'

--- a/src/surmise/emulationmethods/PCGPwM.py
+++ b/src/surmise/emulationmethods/PCGPwM.py
@@ -343,7 +343,7 @@ def predictlpdf(predinfo, f, addvar=0, **kwargs):
         Gfrf2 = (Gf @ rf2.transpose(1, 0, 2)).transpose(1, 0, 2)
         dlikv = 2 * np.sum(rf2.transpose(2, 1, 0) * rf.transpose(1, 0), 2).T
     for c in range(0, predinfo['predvars'].shape[0]):
-        w, v = np.linalg.eig(np.diag(1 / (predinfo['predvars'][c, :])) + Gf2)
+        w, v = np.linalg.eigh(np.diag(1 / (predinfo['predvars'][c, :])) + Gf2)
         term1 = (v * (1 / w)) @ (v.T @ Gfrf[:, c])
 
         likv[c] -= Gfrf[:, c].T @ term1

--- a/src/surmise/emulationmethods/PCSK.py
+++ b/src/surmise/emulationmethods/PCSK.py
@@ -304,7 +304,7 @@ def predictlpdf(predinfo, f, return_grad=False, addvar=0, **kwargs):
         Gfrf2 = (Gf @ rf2.transpose(1, 0, 2)).transpose(1, 0, 2)
         dlikv = 2 * np.sum(rf2.transpose(2, 1, 0) * rf.transpose(1, 0), 2).T
     for c in range(0, predinfo['predvars'].shape[0]):
-        w, v = np.linalg.eig(np.diag(1 / (predinfo['predvars'][c, :])) + Gf2)
+        w, v = np.linalg.eigh(np.diag(1 / (predinfo['predvars'][c, :])) + Gf2)
         term1 = (v * (1 / w)) @ (v.T @ Gfrf[:, c])
 
         likv[c] -= Gfrf[:, c].T @ term1

--- a/src/surmise/emulationmethods/indGP.py
+++ b/src/surmise/emulationmethods/indGP.py
@@ -369,7 +369,7 @@ def predictlpdf(predinfo, f, return_grad=False, addvar=0, **kwargs):
         Gfrf2 = (Gf @ rf2.transpose(1, 0, 2)).transpose(1, 0, 2)
         dlikv = 2 * np.sum(rf2.transpose(2, 1, 0) * rf.transpose(1, 0), 2).T
     for c in range(0, predinfo['predvars'].shape[0]):
-        w, v = np.linalg.eig(np.diag(1 / (predinfo['predvars'][c, :])) + Gf2)
+        w, v = np.linalg.eigh(np.diag(1 / (predinfo['predvars'][c, :])) + Gf2)
         term1 = (v * (1 / w)) @ (v.T @ Gfrf[:, c])
 
         likv[c] -= Gfrf[:, c].T @ term1


### PR DESCRIPTION
Addresses #221.  In all other places, the use of `eigh()` assumes Hermitian matrices, whereas in three occasion, one in each modified emulator method, `eig()` is used, leading to the return of a possibly complex number.