### PR TITLE
PTLMC test suite

### DIFF
--- a/src/surmise/utilitiesmethods/LMC.py
+++ b/src/surmise/utilitiesmethods/LMC.py
@@ -84,7 +84,6 @@ def sampler(logpost_func,
     elif not isinstance(rng, np.random.Generator):
         raise TypeError("Given RNG is not a valid scipy.stats RNG")
 
-
     if theta0 is None:
         theta0 = draw_func(1000)
 

--- a/src/surmise/utilitiesmethods/LMC.py
+++ b/src/surmise/utilitiesmethods/LMC.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy.stats as sps
 import scipy.optimize as spo
 
 r'''
@@ -72,6 +73,17 @@ def sampler(logpost_func,
         numsamp by p of sampled parameter values
 
     '''
+    # random number generator
+    # TODO: This is an intermediate step.  Eventually calling code should be
+    # forced to provide an RNG.
+    rng = None
+    if "RNG" in lmc_options:
+        rng = lmc_options["RNG"]
+    if rng is None:
+        rng = np.random.default_rng()
+    elif not isinstance(rng, np.random.Generator):
+        raise TypeError("Given RNG is not a valid scipy.stats RNG")
+
 
     if theta0 is None:
         theta0 = draw_func(1000)
@@ -124,13 +136,12 @@ def sampler(logpost_func,
         logpost -= (mlogpost + np.log(np.sum(np.exp(logpost - mlogpost))))
         post = np.exp(logpost)
         post = post/np.sum(post)
-        thetaposs = theta0[np.random.choice(range(0, theta0.shape[0]),
-                                            size=1000,
-                                            p=post.reshape((theta0.shape[0],
-                                                            ))), :]
+        thetaposs = theta0[rng.choice(range(0, theta0.shape[0]),
+                                      size=1000,
+                                      p=post.reshape((theta0.shape[0], ))), :]
 
-        if np.any(np.std(thetaposs, 0) < 10 ** (-8) * np.min(np.std(theta0,
-                                                                    0))):
+        if np.any(np.std(thetaposs, 0) < 10 ** (-8) *
+                  np.min(np.std(theta0, 0))):
             thetastar = theta0[np.argmax(logpost), :]
             theta0 = thetastar + (theta0 - thetastar) / 2
             iteratttempt += 1
@@ -210,8 +221,8 @@ def sampler(logpost_func,
     numsamppc = 200
     covmat0 = np.diag(thetas)
     for iters in range(0, maxiters):
-        startingv = np.random.choice(np.arange(0, Lsave.shape[0]),
-                                     size=Lsave.shape[0])
+        startingv = rng.choice(np.arange(0, Lsave.shape[0]),
+                               size=Lsave.shape[0])
         thetasave = thetasave[startingv, :]
 
         covmat0 = 0.1*covmat0 + 0.9*np.cov(thetasave.T)
@@ -223,8 +234,8 @@ def sampler(logpost_func,
         else:
             hc = np.sqrt(covmat0)
 
-        thetac = thetasave[np.random.choice(range(0, thetasave.shape[0]),
-                                            size=numchain), :]
+        thetac = thetasave[rng.choice(range(0, thetasave.shape[0]),
+                                      size=numchain), :]
 
         if logpostf_grad is not None:
             fval, dfval = logpostf(thetac)
@@ -236,7 +247,7 @@ def sampler(logpost_func,
         numtimes = 0
 
         for k in range(0, numsamppc):
-            rvalo = np.random.normal(0, 1, thetac.shape)
+            rvalo = sps.norm.rvs(size=thetac.shape, random_state=rng)
             rval = np.sqrt(2) * rho * (rvalo @ hc)
 
             if rval.ndim != thetac.ndim:
@@ -254,7 +265,7 @@ def sampler(logpost_func,
                 fvalp = logpostf_nograd(thetap)
                 qadj = np.zeros(fvalp.shape)
 
-            swaprnd = np.log(np.random.uniform(size=fval.shape[0]))
+            swaprnd = np.log(sps.uniform.rvs(size=fval.shape[0], random_state=rng))
             whereswap = np.where(np.squeeze(swaprnd)
                                  < np.squeeze(fvalp - fval)
                                  + np.squeeze(qadj))[0]
@@ -308,8 +319,8 @@ def sampler(logpost_func,
             trm = np.min((1.5*tarESS/np.mean(ESS), 4))
             numsamppc = np.ceil(numsamppc*trm).astype('int')
 
-    theta = thetasave[np.random.choice(range(0, thetasave.shape[0]),
-                                       size=numsamp), :]
+    theta = thetasave[rng.choice(range(0, thetasave.shape[0]),
+                                 size=numsamp), :]
     sampler_info = {'theta': theta, 'logpost': Lsave}
 
     return sampler_info

--- a/src/surmise/utilitiesmethods/PTLMC.py
+++ b/src/surmise/utilitiesmethods/PTLMC.py
@@ -79,15 +79,17 @@ def sampler(logpost_func,
                                                np.log(maxtemp)/(numtemps+1),
                                                numtemps)),
                             np.ones(numchain)))  # ratio idea tend from emcee
-    temps = np.array(temps, ndmin=2).T
+    # print(f"orig temp: {temps.shape}")
+    # temps = np.array(temps, ndmin=2).T
+    # print(f"reshape temp: {temps.shape}")
     # number of optimization at each chain before starting
     numopt = temps.shape[0]
     # before beginning, let's test out the given logpdf function
     testout = logpost_func(theta0[0:2, :])
     if type(testout) is tuple:
-        if len(testout) != 2:
+        if len(testout) > 2:
             raise ValueError('log density does not return 1 or 2 elements')
-        if testout[1].shape[1] is not theta0.shape[1]:
+        if testout[1].shape[1] != theta0.shape[1]:
             raise ValueError('derivative appears to be the wrong shape')
         logpostf = logpost_func
 
@@ -122,6 +124,7 @@ def sampler(logpost_func,
     thetacen = np.mean(theta0, 0)
     thetas = np.maximum(np.std(theta0, 0), 10 ** (-8) * np.std(theta0))
 
+    # print(f"theta0: {theta0.shape}")
     # rescale the input to make it easier to optimize
     def neglogpostf_nograd(thetap):
         theta = thetacen + thetas * thetap
@@ -178,6 +181,9 @@ def sampler(logpost_func,
     # end preoptimizer
     # initialize the starting point
     thetac = thetaop
+
+    # print(f"thetac: {thetac.shape}")
+
     if logpostf_grad is not None:
         fval, dfval = logpostf(thetac)
         fval = fval/temps
@@ -185,6 +191,13 @@ def sampler(logpost_func,
     else:
         fval = logpostf_nograd(thetac)
         fval = fval/temps
+    #
+    # print("\n\n\n\n")
+    # print(fval)
+    #
+    # print("\n\n\n\n")
+    # print(f"fval: {fval.shape}")
+
     # preallocate the saving matrix
     thetasave = np.zeros((numchain,
                           sampperchain,
@@ -205,9 +218,14 @@ def sampler(logpost_func,
     adjrho = rho*temps**(1/3)  # this adjusts rho across different temperatures
     numtimes = 0  # number of times we reject, just to star
     for k in range(0, samptunning+sampperchain):  # loop over all chains
-        rvalo = np.random.normal(0, 1, thetac.shape)
-        rval = np.sqrt(2) * adjrho * (rvalo @ hc)
-        thetap = thetac + rval
+        rvalo = np.random.normal(0, 1, size=thetac.shape)
+        # print(f"rvalo: {rvalo.shape}")
+        # print(f"hc: {hc.shape}")
+        # print(f"adjrho: {adjrho.shape}")
+        # print(f"mult: {(rvalo @ hc).shape}")
+        rval = np.sqrt(2) * adjrho * np.squeeze(rvalo @ hc)
+        # print(f"rval: {rval.shape}")
+        thetap = thetac + rval[:, np.newaxis]
         if logpostf_grad is not None:
             # calculate the elements to move if there is a gradiant
             diffval = (adjrho ** 2) * (dfval @ covmat0)
@@ -220,6 +238,7 @@ def sampler(logpost_func,
             qadj = -(2 * np.sum(term1 * term2, 1) + np.sum(term2**2, 1))
         else:
             # calculate the elements to move if there is not a gradiant
+            # print(f"thetap: {thetap.shape}")
             fvalp = logpostf_nograd(thetap)  # thetap : no chain x dimension
             fvalp = fvalp / temps
             qadj = np.zeros(fvalp.shape)
@@ -229,11 +248,13 @@ def sampler(logpost_func,
                              + np.squeeze(qadj))[0]  # MH step to find which of the chains to swap
         if whereswap.shape[0] > 0:  # if we swap, do it where needed
             numtimes = numtimes + np.sum(whereswap > -1)/totnumchain
-            thetac[whereswap, :] = 1*thetap[whereswap, :]
-            fval[whereswap] = 1*fvalp[whereswap]
+            thetac[whereswap] = np.copy(thetap[whereswap])
+            fval[whereswap] = np.copy(fvalp[whereswap])
             if logpostf_grad is not None:
-                dfval[whereswap, :] = 1*dfvalp[whereswap, :]
+                dfval[whereswap] = np.copy(dfvalp[whereswap])
         # do some swaps along the temperatures
+        # print(f"fval: {fval.shape}")
+        # print(f"temp: {temps.shape}")
         fvaln = fval*temps
         orderprop = tempexchange(fvaln, temps, iters=5)  # go through 5 times, swapping where needed
         fval = fvaln[orderprop] / temps
@@ -265,10 +286,16 @@ def tempexchange(lpostf, temps, iters=1):
     # array lpostf with temperature array temps. It will do it iters number of times.
     # It returns the (random) revised order.
     order = np.arange(0, lpostf.shape[0])  # initializing
+    # print(f"order: {order.shape}")
+    # print(f"temp: {temps.shape}")
+    # print(f"lpostf: {lpostf.shape}")
     for k in range(0, iters):
         rtv = np.random.choice(range(1, lpostf.shape[0]), lpostf.shape[0])  # choose random values to check for swapping
+        # print(rtv.shape)
         for rt in rtv:
+            # print(rt)
             rhoh = (1/temps[rt-1] - 1 / temps[rt])
+            # print(rhoh.shape)
             if ((lpostf[order[rt]]-lpostf[order[rt - 1]]) * rhoh >
                     np.log(np.random.uniform(size=1))):  # swap via the PT rule
                 temporder = order[rt - 1]

--- a/src/surmise/utilitiesmethods/PTLMC.py
+++ b/src/surmise/utilitiesmethods/PTLMC.py
@@ -6,7 +6,7 @@ Parallel-Tempering Ensemble MCMC (uses Langevin Monte Carlo)
 '''
 
 
-def sampler(logpostfunc,
+def sampler(logpost_func,
             draw_func,
             theta0=None,
             numsamp=2000,
@@ -19,12 +19,12 @@ def sampler(logpostfunc,
 
     Parameters
     ----------
-    logpostfunc : function
+    logpost_func : function
         A function call describing the log of the posterior distribution.
-            If no gradient, logpostfunc should take a value of an m by p numpy
+            If no gradient, logpost_func should take a value of an m by p numpy
             array of parameters and theta and return
             a length m numpy array of log posterior evaluations.
-            If gradient, logpostfunc should return a tuple.  The first element
+            If gradient, logpost_func should return a tuple.  The first element
             in the tuple should be as listed above.
             The second element in the tuple should be an m by p matrix of
             gradients of the log posterior.
@@ -83,30 +83,30 @@ def sampler(logpostfunc,
     # number of optimization at each chain before starting
     numopt = temps.shape[0]
     # before beginning, let's test out the given logpdf function
-    testout = logpostfunc(theta0[0:2, :])
+    testout = logpost_func(theta0[0:2, :])
     if type(testout) is tuple:
         if len(testout) != 2:
             raise ValueError('log density does not return 1 or 2 elements')
         if testout[1].shape[1] is not theta0.shape[1]:
             raise ValueError('derivative appears to be the wrong shape')
-        logpostf = logpostfunc
+        logpostf = logpost_func
 
         def logpostf_grad(thetain):
-            return logpostfunc(thetain)[1]
+            return logpost_func(thetain)[1]
         try:
-            testout = logpostfunc(theta0[10, :], return_grad=False)
+            testout = logpost_func(theta0[10, :], return_grad=False)
             if type(testout) is tuple:  # make sure that return_grad functionality works
                 raise ValueError('Cannot stop returning a grad')
 
             def logpostf_nograd(theta):
-                return logpostfunc(theta, return_grad=False)
+                return logpost_func(theta, return_grad=False)
         except Exception:
             def logpostf_nograd(theta):  # if not, do not use return_grad key
-                return logpostfunc(theta)[0]
+                return logpost_func(theta)[0]
     else:
         logpostf_grad = None  # sometimes no derivative is given
-        logpostf = logpostfunc
-        logpostf_nograd = logpostfunc
+        logpostf = logpost_func
+        logpostf_nograd = logpost_func
 
     if logpostf_grad is None:  # these are standard parameters if there is
         taracc = 0.25  # close to theoretical result 0.234

--- a/src/surmise/utilitiesmethods/PTLMC.py
+++ b/src/surmise/utilitiesmethods/PTLMC.py
@@ -91,7 +91,7 @@ def sampler(logpost_func,
                                                np.log(maxtemp)/(numtemps+1),
                                                numtemps)),
                             np.ones(numchain)))  # ratio idea tend from emcee
-    print(temps.shape)
+
     # number of optimization at each chain before starting
     numopt = temps.shape[0]
     # before beginning, let's test out the given logpdf function

--- a/src/surmise/utilitiesmethods/PTLMC.py
+++ b/src/surmise/utilitiesmethods/PTLMC.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy.stats as sps
 import scipy.optimize as spo
 
 '''
@@ -61,6 +62,17 @@ def sampler(logpost_func,
 
     """
 
+    # random number generator
+    # TODO: This is an intermediate step.  Eventually calling code should be
+    # forced to provide an RNG.
+    rng = None
+    if "RNG" in ptlmc_options:
+        rng = ptlmc_options["RNG"]
+    if rng is None:
+        rng = np.random.default_rng()
+    elif not isinstance(rng, np.random.Generator):
+        raise TypeError("Given RNG is not a valid scipy.stats RNG")
+
     # If we do not get parameters to start, draw 1000
     if theta0 is None:
         theta0 = draw_func(1000)
@@ -79,9 +91,7 @@ def sampler(logpost_func,
                                                np.log(maxtemp)/(numtemps+1),
                                                numtemps)),
                             np.ones(numchain)))  # ratio idea tend from emcee
-    # print(f"orig temp: {temps.shape}")
-    # temps = np.array(temps, ndmin=2).T
-    # print(f"reshape temp: {temps.shape}")
+
     # number of optimization at each chain before starting
     numopt = temps.shape[0]
     # before beginning, let's test out the given logpdf function
@@ -118,13 +128,13 @@ def sampler(logpost_func,
     # order the existing initial theta's by log pdf
     ord1 = np.argsort(-np.squeeze(logpostf_nograd(theta0)) +
                       (theta0.shape[1] *
-                       np.random.standard_normal(size=theta0.shape[0])**2))
+                       sps.norm.rvs(size=theta0.shape[0],
+                                    random_state=rng)**2))
     theta0 = theta0[ord1[0:totnumchain], :]
     # begin optimizing at each chain
     thetacen = np.mean(theta0, 0)
     thetas = np.maximum(np.std(theta0, 0), 10 ** (-8) * np.std(theta0))
 
-    # print(f"theta0: {theta0.shape}")
     # rescale the input to make it easier to optimize
     def neglogpostf_nograd(thetap):
         theta = thetacen + thetas * thetap
@@ -164,7 +174,8 @@ def sampler(logpost_func,
         l0 = neglogpostf_nograd(opval.x)
         while notmoved:
             if (W > 0).all():
-                r = (V.T*np.sqrt(W)) @ (V @ np.random.standard_normal(size=thetacen.shape[0]))
+                r = (V.T*np.sqrt(W)) @ (V @ sps.norm.rvs(size=thetacen.shape[0],
+                                                         random_state=rng))
             else:
                 stepadj /= 2
                 if stepadj < 1/16:
@@ -172,7 +183,7 @@ def sampler(logpost_func,
                     notmoved = False
                 continue
 
-            if (neglogpostf_nograd((stepadj * r + opval.x)) -
+            if (neglogpostf_nograd(stepadj * r + opval.x) -
                     l0) < 3*thetacen.shape[0]:
                 thetaop[k, :] = thetacen + thetas * (stepadj * r + opval.x)
                 notmoved = False
@@ -181,22 +192,13 @@ def sampler(logpost_func,
     # end preoptimizer
     # initialize the starting point
     thetac = thetaop
-
-    # print(f"thetac: {thetac.shape}")
-
     if logpostf_grad is not None:
         fval, dfval = logpostf(thetac)
-        fval = fval/temps
-        dfval = dfval/temps
+        fval /= temps
+        dfval /= temps
     else:
         fval = logpostf_nograd(thetac)
-        fval = fval/temps
-    #
-    # print("\n\n\n\n")
-    # print(fval)
-    #
-    # print("\n\n\n\n")
-    # print(f"fval: {fval.shape}")
+        fval /= temps
 
     # preallocate the saving matrix
     thetasave = np.zeros((numchain,
@@ -218,13 +220,8 @@ def sampler(logpost_func,
     adjrho = rho*temps**(1/3)  # this adjusts rho across different temperatures
     numtimes = 0  # number of times we reject, just to star
     for k in range(0, samptunning+sampperchain):  # loop over all chains
-        rvalo = np.random.normal(0, 1, size=thetac.shape)
-        # print(f"rvalo: {rvalo.shape}")
-        # print(f"hc: {hc.shape}")
-        # print(f"adjrho: {adjrho.shape}")
-        # print(f"mult: {(rvalo @ hc).shape}")
+        rvalo = sps.norm.rvs(size=thetac.shape, random_state=rng)
         rval = (np.sqrt(2) * adjrho * np.squeeze(rvalo @ hc).T).T
-        # print(f"rval: {rval.shape}")
         if thetac.shape[1] > 1:
             thetap = thetac + rval
         elif thetac.shape[1] == 1:
@@ -234,16 +231,15 @@ def sampler(logpost_func,
             diffval = (adjrho ** 2) * (dfval @ covmat0)
             thetap += diffval
             fvalp, dfvalp = logpostf(thetap)  # thetap : no chain x dimension
-            fvalp = fvalp / temps  # to flatten the posterior
-            dfvalp = dfvalp / temps
+            fvalp /= temps  # to flatten the posterior
+            dfvalp /= temps
             term1 = rvalo / np.sqrt(2)
             term2 = (adjrho / 2) * ((dfval + dfvalp) @ hc)
             qadj = -(2 * np.sum(term1 * term2, 1) + np.sum(term2**2, 1))
         else:
             # calculate the elements to move if there is not a gradiant
-            # print(f"thetap: {thetap.shape}")
             fvalp = logpostf_nograd(thetap)  # thetap : no chain x dimension
-            fvalp = fvalp / temps
+            fvalp /= temps
             qadj = np.zeros(fvalp.shape)
         swaprnd = np.log(np.random.uniform(size=fval.shape[0]))
         whereswap = np.where(np.squeeze(swaprnd)
@@ -256,10 +252,8 @@ def sampler(logpost_func,
             if logpostf_grad is not None:
                 dfval[whereswap] = np.copy(dfvalp[whereswap])
         # do some swaps along the temperatures
-        # print(f"fval: {fval.shape}")
-        # print(f"temp: {temps.shape}")
-        fvaln = fval*temps
-        orderprop = tempexchange(fvaln, temps, iters=5)  # go through 5 times, swapping where needed
+        fvaln = fval * temps
+        orderprop = tempexchange(fvaln, temps, iters=5, rng=rng)  # go through 5 times, swapping where needed
         fval = fvaln[orderprop] / temps
         thetac = thetac[orderprop, :]
         if logpostf_grad is not None:
@@ -275,32 +269,28 @@ def sampler(logpost_func,
         elif k >= samptunning:  # if done with tuning
             thetasave[:, k-samptunning, :] = 1 * thetac[numtemps:, ]
     # save the theta values in the temp=1 chains, squeezing flattening the values of all chains
-    thetasave = np.reshape(thetasave, (-1, thetac.shape[1]))
+    thetasave_flatten = np.reshape(thetasave, (-1, thetac.shape[1]))
     # save random values from the chain of size numsamp
-    theta = thetasave[np.random.choice(range(0, thetasave.shape[0]),
-                                       size=numsamp), :]
+    theta = thetasave_flatten[rng.choice(range(0, thetasave_flatten.shape[0]),
+                                         size=numsamp)]
     # store this in a dictionary
-    sampler_info = {'theta': theta, 'logpost': logpostf_nograd(theta)}
+    sampler_info = {'theta': theta, 'theta_from_chain': thetasave, 'logpost': logpostf_nograd(theta)}
     return sampler_info
 
 
-def tempexchange(lpostf, temps, iters=1):
+def tempexchange(lpostf, temps, iters=1, rng=None):
     # This function will swap values along the chain given the log pdf values in an
     # array lpostf with temperature array temps. It will do it iters number of times.
     # It returns the (random) revised order.
+    assert rng is not None
+
     order = np.arange(0, lpostf.shape[0])  # initializing
-    # print(f"order: {order.shape}")
-    # print(f"temp: {temps.shape}")
-    # print(f"lpostf: {lpostf.shape}")
     for k in range(0, iters):
-        rtv = np.random.choice(range(1, lpostf.shape[0]), lpostf.shape[0])  # choose random values to check for swapping
-        # print(rtv.shape)
+        rtv = rng.choice(range(1, lpostf.shape[0]), lpostf.shape[0])  # choose random values to check for swapping
         for rt in rtv:
-            # print(rt)
             rhoh = (1/temps[rt-1] - 1 / temps[rt])
-            # print(rhoh.shape)
             if ((lpostf[order[rt]]-lpostf[order[rt - 1]]) * rhoh >
-                    np.log(np.random.uniform(size=1))):  # swap via the PT rule
+                    np.log(sps.uniform.rvs(size=1, random_state=rng))):  # swap via the PT rule
                 temporder = order[rt - 1]
                 order[rt-1] = 1*order[rt]
                 order[rt] = 1 * temporder

--- a/src/surmise/utilitiesmethods/PTLMC.py
+++ b/src/surmise/utilitiesmethods/PTLMC.py
@@ -272,8 +272,7 @@ def sampler(logpost_func,
     thetasave_flatten = np.reshape(thetasave, (-1, thetac.shape[1]))
     # save random values from the chain of size numsamp
     # TODO: choose the first numsamp as required samples, the flattening should be revisited.
-    theta = thetasave_flatten[:numsamp]  #[rng.choice(range(0, thetasave_flatten.shape[0]),
-                               #           size=numsamp)]
+    theta = thetasave_flatten[:numsamp]  # [rng.choice(range(0, thetasave_flatten.shape[0]), size=numsamp)]
     # store this in a dictionary
     sampler_info = {'theta': theta, 'theta_from_chain': thetasave, 'logpost': logpostf_nograd(theta)}
     return sampler_info

--- a/src/surmise/utilitiesmethods/PTLMC.py
+++ b/src/surmise/utilitiesmethods/PTLMC.py
@@ -241,7 +241,7 @@ def sampler(logpost_func,
             fvalp = np.squeeze(logpostf_nograd(thetap))  # thetap : no chain x dimension
             fvalp /= temps
             qadj = np.zeros(fvalp.shape)
-        swaprnd = np.log(np.random.uniform(size=fval.shape[0]))
+        swaprnd = np.log(sps.uniform.rvs(size=fval.shape[0], random_state=rng))
         whereswap = np.where(np.squeeze(swaprnd)
                              < np.squeeze(fvalp - fval)
                              + np.squeeze(qadj))[0]  # MH step to find which of the chains to swap

--- a/src/surmise/utilitiesmethods/PTLMC.py
+++ b/src/surmise/utilitiesmethods/PTLMC.py
@@ -223,9 +223,12 @@ def sampler(logpost_func,
         # print(f"hc: {hc.shape}")
         # print(f"adjrho: {adjrho.shape}")
         # print(f"mult: {(rvalo @ hc).shape}")
-        rval = np.sqrt(2) * adjrho * np.squeeze(rvalo @ hc)
+        rval = (np.sqrt(2) * adjrho * np.squeeze(rvalo @ hc).T).T
         # print(f"rval: {rval.shape}")
-        thetap = thetac + rval[:, np.newaxis]
+        if thetac.shape[1] > 1:
+            thetap = thetac + rval
+        elif thetac.shape[1] == 1:
+            thetap = thetac + rval[:, np.newaxis]
         if logpostf_grad is not None:
             # calculate the elements to move if there is a gradiant
             diffval = (adjrho ** 2) * (dfval @ covmat0)

--- a/src/surmise/utilitiesmethods/PTLMC.py
+++ b/src/surmise/utilitiesmethods/PTLMC.py
@@ -91,7 +91,7 @@ def sampler(logpost_func,
                                                np.log(maxtemp)/(numtemps+1),
                                                numtemps)),
                             np.ones(numchain)))  # ratio idea tend from emcee
-
+    print(temps.shape)
     # number of optimization at each chain before starting
     numopt = temps.shape[0]
     # before beginning, let's test out the given logpdf function
@@ -197,7 +197,7 @@ def sampler(logpost_func,
         fval /= temps
         dfval /= temps
     else:
-        fval = logpostf_nograd(thetac)
+        fval = np.squeeze(logpostf_nograd(thetac))
         fval /= temps
 
     # preallocate the saving matrix
@@ -238,7 +238,7 @@ def sampler(logpost_func,
             qadj = -(2 * np.sum(term1 * term2, 1) + np.sum(term2**2, 1))
         else:
             # calculate the elements to move if there is not a gradiant
-            fvalp = logpostf_nograd(thetap)  # thetap : no chain x dimension
+            fvalp = np.squeeze(logpostf_nograd(thetap))  # thetap : no chain x dimension
             fvalp /= temps
             qadj = np.zeros(fvalp.shape)
         swaprnd = np.log(np.random.uniform(size=fval.shape[0]))

--- a/src/surmise/utilitiesmethods/PTLMC.py
+++ b/src/surmise/utilitiesmethods/PTLMC.py
@@ -271,8 +271,9 @@ def sampler(logpost_func,
     # save the theta values in the temp=1 chains, squeezing flattening the values of all chains
     thetasave_flatten = np.reshape(thetasave, (-1, thetac.shape[1]))
     # save random values from the chain of size numsamp
-    theta = thetasave_flatten[rng.choice(range(0, thetasave_flatten.shape[0]),
-                                         size=numsamp)]
+    # TODO: choose the first numsamp as required samples, the flattening should be revisited.
+    theta = thetasave_flatten[:numsamp]  #[rng.choice(range(0, thetasave_flatten.shape[0]),
+                               #           size=numsamp)]
     # store this in a dictionary
     sampler_info = {'theta': theta, 'theta_from_chain': thetasave, 'logpost': logpostf_nograd(theta)}
     return sampler_info

--- a/tools/IndependentJointDistribution.py
+++ b/tools/IndependentJointDistribution.py
@@ -58,7 +58,7 @@ class IndependentJointDistribution(AbstractDistribution):
         assert all(values >= 0.0)
         return values
 
-    def logpdf(self, theta, return_grad):
+    def logpdf(self, theta, return_grad=False):
         if return_grad:
             raise NotImplementedError("gradient not implemented")
 

--- a/tools/LMCTestSuite.json
+++ b/tools/LMCTestSuite.json
@@ -1,0 +1,29 @@
+{
+    "Uniform1D": {
+        "TargetDistribution": {
+            "Name":      "Uniform",
+            "Intervals": [-1.1, 1.2]
+        },
+        "TestSetups": {
+            "UniformStart": {
+                "rng": {
+                    "method":      "default",
+                    "random_seed": 2531535131186259872329283269888015535
+                },
+                "StartDistribution": {
+                    "Name":      "Uniform",
+                    "Intervals": [-0.5, 0.5]
+                },
+                "Sampler": {
+                   "Name": "LMC"
+                },
+                "SampleSkip":         10,
+                "Plot":             true,
+                "Benchmark":          "",
+                "n_burn_samples":  10000,
+                "n_samples":      100000,
+                "verbose":          true 
+            }
+        }
+    }
+}

--- a/tools/LMCTestSuite.json
+++ b/tools/LMCTestSuite.json
@@ -19,7 +19,7 @@
                 },
                 "SampleSkip":         10,
                 "Plot":             true,
-                "Benchmark":          "",
+                "Benchmark":          "LMC_Uniform1D_UniformStart.benchmark",
                 "n_burn_samples":  10000,
                 "n_samples":      100000,
                 "verbose":          true 

--- a/tools/MetropolisHastingsTestSuite.json
+++ b/tools/MetropolisHastingsTestSuite.json
@@ -14,9 +14,12 @@
                     "Name":      "Uniform",
                     "Intervals": [-0.5, 0.5]
                 },
-                "StepDistribution": {
-                    "Name":  "normal",
-                    "Scale":  2.5
+                "Sampler": {
+                    "Name": "MH",
+                    "StepDistribution": {
+                        "Name":  "normal",
+                        "Scale":  2.5
+                    }
                 },
                 "SampleSkip":         10,
                 "Plot":            false,
@@ -34,9 +37,12 @@
                     "Name":      "Uniform",
                     "Intervals": [-0.5, 0.5]
                 },
-                "StepDistribution": {
-                    "Name":  "uniform",
-                    "Scale":  6.0
+                "Sampler": {
+                    "Name": "MH",
+                    "StepDistribution": {
+                        "Name":  "uniform",
+                        "Scale":  6.0
+                    }
                 },
                 "SampleSkip":         10,
                 "Plot":            false,
@@ -64,9 +70,12 @@
                     "Intervals": [[-0.5, 0.5],
                                   [ 1.5, 2.1]]
                 },
-                "StepDistribution": {
-                    "Name":       "normal",
-                    "Scale":    [1.0, 2.0]
+                "Sampler": {
+                    "Name": "MH",
+                    "StepDistribution": {
+                        "Name":       "normal",
+                        "Scale":    [1.0, 2.0]
+                    }
                 },
                 "SampleSkip":         10,
                 "Benchmark":           "MH_Uniform2D_NormalStep.benchmark",
@@ -95,9 +104,12 @@
                     "mu":    0.0,
                     "sigma": 1.0
                 },
-                "StepDistribution": {
-                    "Name":  "normal",
-                    "Scale":  3.5
+                "Sampler": {
+                    "Name": "MH",
+                    "StepDistribution": {
+                        "Name":  "normal",
+                        "Scale":  3.5
+                    }
                 },
                 "SampleSkip":         10,
                 "Plot":            false,
@@ -116,9 +128,12 @@
                     "mu":    0.0,
                     "sigma": 1.0
                 },
-                "StepDistribution": {
-                    "Name":  "uniform",
-                    "Scale":  10.0
+                "Sampler": {
+                    "Name": "MH",
+                    "StepDistribution": {
+                        "Name":  "uniform",
+                        "Scale":  10.0
+                    }
                 },
                 "SampleSkip":         10,
                 "Plot":            false,
@@ -148,9 +163,12 @@
                     "sigma": [[1.0, 0.0],
                               [0.0, 5.0]]
                 },
-                "StepDistribution": {
-                    "Name":         "normal",
-                    "Scale":      [1.0, 5.0]
+                "Sampler": {
+                    "Name": "MH",
+                    "StepDistribution": {
+                        "Name":         "normal",
+                        "Scale":      [1.0, 5.0]
+                    }
                 },
                 "SampleSkip":         20,
                 "Plot":            false,
@@ -183,9 +201,12 @@
                               [0.0, 5.0, 0.0],
                               [0.0, 0.0, 0.5]]
                 },
-                "StepDistribution": {
-                    "Name":         "normal",
-                    "Scale":      [1.0, 5.0, 0.2]
+                "Sampler": {
+                    "Name": "MH",
+                    "StepDistribution": {
+                        "Name":         "normal",
+                        "Scale":      [1.0, 5.0, 0.2]
+                    }
                 },
                 "SampleSkip":         20,
                 "Plot":            false,
@@ -218,9 +239,12 @@
                                   [-4.0, -1.0],
                                   [-0.5, -0.4]]
                 },
-                "StepDistribution": {
-                    "Name":  "uniform",
-                    "Scale": [1.0, 1.75, 2.5, 0.2]
+                "Sampler": {
+                    "Name": "MH",
+                    "StepDistribution": {
+                        "Name":  "uniform",
+                        "Scale": [1.0, 1.75, 2.5, 0.2]
+                    }
                 },
                 "SampleSkip":          20,
                 "Plot":             false,

--- a/tools/MultinormalDistribution.py
+++ b/tools/MultinormalDistribution.py
@@ -49,7 +49,7 @@ class MultinormalDistribution(AbstractDistribution):
         assert all(values >= 0.0)
         return values
 
-    def logpdf(self, theta, return_grad):
+    def logpdf(self, theta, return_grad=False):
         if return_grad:
             raise NotImplementedError("gradient not implemented")
 

--- a/tools/NormalDistribution.py
+++ b/tools/NormalDistribution.py
@@ -46,7 +46,7 @@ class NormalDistribution(AbstractDistribution):
         assert values.ndim == 1
         return values
 
-    def logpdf(self, theta, return_grad):
+    def logpdf(self, theta, return_grad=False):
         if return_grad:
             raise NotImplementedError("gradient not implemented yet")
         values = self.__N.logpdf(self._as1darray_checked(theta))

--- a/tools/PTLMCTestSuite.json
+++ b/tools/PTLMCTestSuite.json
@@ -18,14 +18,14 @@
                     "Name":      "PTLMC",
                     "numtemps":       32,
                     "numchain":       16,
-                    "sampperchain":  400,
+                    "sampperchain":  2000,
                     "maxtemp":        30
                 },
                 "SampleSkip":          1,
                 "Plot":            false,
                 "Benchmark":      "PTLMC_Uniform1D_UniformStart.benchmark",
                 "n_burn_samples":  10000,
-                "n_samples":      100000,
+                "n_samples":       32000,
                 "verbose":         false
             }
         }
@@ -52,15 +52,83 @@
                     "Name":      "PTLMC",
                     "numtemps":       32,
                     "numchain":       16,
-                    "sampperchain":  400,
+                    "sampperchain": 2000,
                     "maxtemp":        30
                 },
                 "SampleSkip":          1,
                 "Plot":            false,
                 "CornerPlotBins":     30,
                 "Benchmark":      "PTLMC_Uniform2D_NormalStart.benchmark",
-                "n_burn_samples":  10000,
-                "n_samples":      100000,
+                "n_burn_samples":  50000,
+                "n_samples":       32000,
+                "verbose":         false
+            }
+        }
+    },
+    "Normal1D": {
+        "TargetDistribution": {
+            "Name": "Normal",
+            "mu":    -1.1,
+            "sigma":  1.2
+        },
+        "TestSetups": {
+            "UniformStart": {
+                "rng": {
+                    "method":      "default",
+                    "random_seed": 192610724096912622599077596010199726791
+                },
+                "StartDistribution": {
+                    "Name":      "Uniform",
+                    "Intervals": [-0.5, 0.5]
+                },
+                "Sampler": {
+                    "Name":      "PTLMC",
+                    "numtemps":       32,
+                    "numchain":       16,
+                    "sampperchain":  2000,
+                    "maxtemp":        30
+                },
+                "SampleSkip":          1,
+                "Plot":            false,
+                "Benchmark":      "PTLMC_Normal1D_UniformStart.benchmark",
+                "n_burn_samples":  50000,
+                "n_samples":       32000,
+                "verbose":         false
+            }
+        }
+    },
+    "Normal2D": {
+        "TargetDistribution": {
+            "Name": "Normal",
+            "mu":     [1.1, -2.2],
+            "sigma": [[1.0,  2.0],
+                      [2.0, 10.0]]
+        },
+        "TestSetups": {
+            "NormalStart": {
+                "rng": {
+                    "method": "default",
+                    "random_seed": 100092616225039682105425248025433037719
+                },
+                "StartDistribution": {
+                    "Name":     "normal",
+                    "mu":    [-1.0, 2.0],
+                    "sigma": [[1.0, 0.0],
+                              [0.0, 5.0]]
+                },
+                "Sampler": {
+                    "Name":      "PTLMC",
+                    "numtemps":       32,
+                    "numchain":       16,
+                    "sampperchain":  2000,
+                    "maxtemp":        30
+                },
+                "SampleSkip":          1,
+                "Plot":            false,
+                "CornerPlotBins":     30,
+                "Benchmark":      "PTLMC_Normal2D_NormalStart.benchmark",
+                "n_burn_samples":  50000,
+                "n_samples":       32000,
                 "verbose":         false
             }
         }

--- a/tools/PTLMCTestSuite.json
+++ b/tools/PTLMCTestSuite.json
@@ -22,11 +22,11 @@
                     "maxtemp":        30
                 },
                 "SampleSkip":          1,
-                "Plot":            false,
+                "Plot":             true,
                 "Benchmark":      "PTLMC_Uniform1D_UniformStart.benchmark",
                 "n_burn_samples":  10000,
                 "n_samples":       32000,
-                "verbose":         false
+                "verbose":          true
             }
         }
     },
@@ -56,12 +56,12 @@
                     "maxtemp":        30
                 },
                 "SampleSkip":          1,
-                "Plot":            false,
+                "Plot":             true,
                 "CornerPlotBins":     30,
                 "Benchmark":      "PTLMC_Uniform2D_NormalStart.benchmark",
                 "n_burn_samples":  50000,
                 "n_samples":       32000,
-                "verbose":         false
+                "verbose":          true 
             }
         }
     },
@@ -89,11 +89,11 @@
                     "maxtemp":        30
                 },
                 "SampleSkip":          1,
-                "Plot":            false,
+                "Plot":             true,
                 "Benchmark":      "PTLMC_Normal1D_UniformStart.benchmark",
                 "n_burn_samples":  50000,
                 "n_samples":       32000,
-                "verbose":         false
+                "verbose":          true 
             }
         }
     },
@@ -124,12 +124,12 @@
                     "maxtemp":        30
                 },
                 "SampleSkip":          1,
-                "Plot":            false,
+                "Plot":             true,
                 "CornerPlotBins":     30,
                 "Benchmark":      "PTLMC_Normal2D_NormalStart.benchmark",
                 "n_burn_samples":  50000,
                 "n_samples":       32000,
-                "verbose":         false
+                "verbose":          true 
             }
         }
     }

--- a/tools/PTLMCTestSuite.json
+++ b/tools/PTLMCTestSuite.json
@@ -22,11 +22,11 @@
                     "maxtemp":        30
                 },
                 "SampleSkip":          1,
-                "Plot":             true,
-                "Benchmark":          "",
+                "Plot":            false,
+                "Benchmark":      "PTLMC_Uniform1D_UniformStart.benchmark",
                 "n_burn_samples":  10000,
                 "n_samples":      100000,
-                "verbose":          true
+                "verbose":         false
             }
         }
     },
@@ -37,15 +37,16 @@
                           [ 1.3, 4.3]]
         },
         "TestSetups": {
-            "NormalStep": {
+            "NormalStart": {
                 "rng": {
                     "method": "default",
                     "random_seed": 100092616225039682105425248025433037719
                 },
                 "StartDistribution": {
-                    "Name":      "Uniform",
-                    "Intervals": [[-0.5, 0.5],
-                                  [ 1.5, 2.1]]
+                    "Name":     "normal",
+                    "mu":    [-1.0, 2.0],
+                    "sigma": [[1.0, 0.0],
+                              [0.0, 5.0]]
                 },
                 "Sampler": {
                     "Name":      "PTLMC",
@@ -55,12 +56,12 @@
                     "maxtemp":        30
                 },
                 "SampleSkip":          1,
-                "Plot":             true,
+                "Plot":            false,
                 "CornerPlotBins":     30,
-                "Benchmark":          "",
+                "Benchmark":      "PTLMC_Uniform2D_NormalStart.benchmark",
                 "n_burn_samples":  10000,
                 "n_samples":      100000,
-                "verbose":          true
+                "verbose":         false
             }
         }
     }

--- a/tools/PTLMCTestSuite.json
+++ b/tools/PTLMCTestSuite.json
@@ -1,0 +1,33 @@
+{
+    "Uniform1D": {
+        "TargetDistribution": {
+            "Name":      "Uniform",
+            "Intervals": [-1.1, 1.2]
+        },
+        "TestSetups": {
+            "UniformStart": {
+                "rng": {
+                    "method":      "default",
+                    "random_seed": 192610724096912622599077596010199726791
+                },
+                "StartDistribution": {
+                    "Name":      "Uniform",
+                    "Intervals": [-0.5, 0.5]
+                },
+                "Sampler": {
+                    "Name":      "PTLMC",
+                    "numtemps":       32,
+                    "numchain":       16,
+                    "sampperchain":  400,
+                    "maxtemp":        30
+                },
+                "SampleSkip":          1,
+                "Plot":             true,
+                "Benchmark":          "",
+                "n_burn_samples":  10000,
+                "n_samples":      100000,
+                "verbose":          true
+            }
+        }
+    }
+}

--- a/tools/PTLMCTestSuite.json
+++ b/tools/PTLMCTestSuite.json
@@ -29,5 +29,39 @@
                 "verbose":          true
             }
         }
+    },
+     "Uniform2D": {
+        "TargetDistribution": {
+            "Name":      "Uniform",
+            "Intervals": [[-1.1, 1.2],
+                          [ 1.3, 4.3]]
+        },
+        "TestSetups": {
+            "NormalStep": {
+                "rng": {
+                    "method": "default",
+                    "random_seed": 100092616225039682105425248025433037719
+                },
+                "StartDistribution": {
+                    "Name":      "Uniform",
+                    "Intervals": [[-0.5, 0.5],
+                                  [ 1.5, 2.1]]
+                },
+                "Sampler": {
+                    "Name":      "PTLMC",
+                    "numtemps":       32,
+                    "numchain":       16,
+                    "sampperchain":  400,
+                    "maxtemp":        30
+                },
+                "SampleSkip":          1,
+                "Plot":             true,
+                "CornerPlotBins":     30,
+                "Benchmark":          "",
+                "n_burn_samples":  10000,
+                "n_samples":      100000,
+                "verbose":          true
+            }
+        }
     }
 }

--- a/tools/TestSampler.py
+++ b/tools/TestSampler.py
@@ -353,6 +353,9 @@ class TestSampler(unittest.TestCase):
         elif sampler_name.upper() == "LMC":
             # Nothing extra to test
             pass
+        elif sampler_name.upper() == "PTLMC":
+            # Nothing extra to test
+            pass
         else:
             raise ValueError("Not testing sampler-specific results")
         self.assertEqual(set(benchmark), set(new))

--- a/tools/TestSampler.py
+++ b/tools/TestSampler.py
@@ -64,9 +64,6 @@ class TestSampler(unittest.TestCase):
 
     def testAllSetups(self):
         for problem_name, problem in self.__problems.items():
-            # TODO: replace with dynamic sampler tags
-            sampler_tag = "MH" if 'SamplerTag' not in problem else problem['SamplerTag']
-
             target_cfg = problem["TargetDistribution"]
             target_name = target_cfg["Name"]
             print()
@@ -79,7 +76,8 @@ class TestSampler(unittest.TestCase):
                 print(setup_name)
                 print("-" * 45)
 
-                name = f"{sampler_tag}_{problem_name}_{setup_name}"
+                sampler_name = test_setup["Sampler"]["Name"]
+                name = f"{sampler_name}_{problem_name}_{setup_name}"
                 self.__testSampler(name, target_distribution, test_setup)
 
     def __testSampler(self, name, target_distribution, test_setup):
@@ -143,7 +141,7 @@ class TestSampler(unittest.TestCase):
         }
 
         # -- Create sampler & load sampler-specific configuration
-        run_MCMC, sampler_cfg = create_sampler(test_setup)
+        sampler_name, run_MCMC, sampler_cfg = create_sampler(test_setup)
         sampler_cfg["RNG"] = np.random.default_rng(rand_seed)
 
         # ------ RUN SAMPLER & CONFIRM REASONABLE RESULTS
@@ -177,11 +175,10 @@ class TestSampler(unittest.TestCase):
             **sampler_cfg
         )
         self.assertFalse(FNAME_H5.exists())
-        save_mcmc_results(FNAME_H5, result_1)
+        save_mcmc_results(FNAME_H5, sampler_name, result_1)
         self.assertTrue(FNAME_H5.is_file())
         print("done")
         sys.stdout.flush()
-        self.assertEqual(set(result_1), {"theta", "acc_rate", "lpostlist"})
 
         samples = result_1["theta"]
         self.assertEqual(len(samples), n_samples)
@@ -307,8 +304,6 @@ class TestSampler(unittest.TestCase):
                 raise NotImplementedError("Only 1D to 4D visualizations for now")
             plt.show()
 
-        self.assertTrue(0.3 <= result_1["acc_rate"] <= 0.4)
-
         # TODO: Compute effective N samples
         # TODO: Compute Rhat
         # TODO: Check against CDF?
@@ -320,7 +315,7 @@ class TestSampler(unittest.TestCase):
         if fname_benchmark != "":
             fname_benchmark = Path(fname_benchmark).resolve()
             self.assertTrue(fname_benchmark.is_file())
-            self.__compare_results(fname_benchmark, FNAME_H5)
+            self.__compare_results(sampler_name, fname_benchmark, FNAME_H5)
 
         # ----- CONFIRM DETERMINISTIC
         # Rerun with identical RNG setup & confirm bitwise exact samples
@@ -341,14 +336,28 @@ class TestSampler(unittest.TestCase):
         print("done")
         sys.stdout.flush()
 
-        self.assertEqual(result_1["acc_rate"], result_2["acc_rate"])
+        self.__compare_sampler_specific(sampler_name, result_1, result_2)
         theta_1 = result_1["theta"]
         theta_2 = result_2["theta"]
         self.assertTrue(
             np.array_equal(theta_1, theta_2, equal_nan=False)
         )
 
-    def __compare_results(self, fname_benchmark, fname_new):
+    def __compare_sampler_specific(self, sampler_name, benchmark, new):
+        if sampler_name.upper() == "MH":
+            # TODO: lpostlist should probably be saved in the files so that we
+            # can check new results against benchmarks as well.
+            # self.assertEqual(set(benchmark), {"theta", "acc_rate", "lpostlist"})
+            self.assertEqual(new["acc_rate"], benchmark["acc_rate"])
+            self.assertTrue(0.3 <= benchmark["acc_rate"] <= 0.4)
+        elif sampler_name.upper() == "LMC":
+            # Nothing extra to test
+            pass
+        else:
+            raise ValueError("Not testing sampler-specific results")
+        self.assertEqual(set(benchmark), set(new))
+
+    def __compare_results(self, sampler_name, fname_benchmark, fname_new):
         print()
         print("Regression Check")
         print(f"New\t\t\t{fname_new}")
@@ -356,7 +365,8 @@ class TestSampler(unittest.TestCase):
         benchmark = load_mcmc_results(fname_benchmark)
         new = load_mcmc_results(fname_new)
 
-        self.assertEqual(new["acc_rate"], benchmark["acc_rate"])
+        self.__compare_sampler_specific(sampler_name, benchmark, new)
+
         theta_new = new["theta"]
         theta_benchmark = benchmark["theta"]
         self.assertTrue(

--- a/tools/UniformDistribution.py
+++ b/tools/UniformDistribution.py
@@ -47,7 +47,7 @@ class UniformDistribution(AbstractDistribution):
         assert values.ndim == 1
         return values
 
-    def logpdf(self, theta, return_grad):
+    def logpdf(self, theta, return_grad=False):
         if return_grad:
             raise NotImplementedError("gradient not implemented yet")
         values = self.__U.logpdf(self._as1darray_checked(theta))

--- a/tools/create_sampler.py
+++ b/tools/create_sampler.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from surmise.utilitiesmethods.metropolis_hastings import sampler as MH_sampler
+from surmise.utilitiesmethods.LMC import sampler as LMC_sampler
+from surmise.utilitiesmethods.PTLMC import sampler as PTLMC_sampler
 
 
 def create_sampler(test_setup):
@@ -12,17 +14,34 @@ def create_sampler(test_setup):
     sampler = None
     sampler_cfg = None
 
-    # -- Metropolis-Hastings Sampler
-    # Extract sampler-specific configuration info
-    step_cfg = test_setup["StepDistribution"]
-    step_type = step_cfg["Name"]
-    if "Scale" in step_cfg:
-        step_scale = np.atleast_1d(np.squeeze(step_cfg["Scale"]))
-        assert step_scale.ndim == 1
+    sampler_name = test_setup["Sampler"]["Name"]
+    if sampler_name.upper() == "MH":
+        # -- Metropolis-Hastings Sampler
+        # Extract sampler-specific configuration info
+        step_cfg = test_setup["Sampler"]["StepDistribution"]
+        step_type = step_cfg["Name"]
+        if "Scale" in step_cfg:
+            step_scale = np.atleast_1d(np.squeeze(step_cfg["Scale"]))
+            assert step_scale.ndim == 1
+        else:
+            step_scale = None
+
+        sampler = MH_sampler
+        sampler_cfg = {"stepType": step_type, "stepParam": step_scale}
+    elif sampler_name.upper() == "LMC":
+        # -- Langevin MC Sampler
+        sampler = LMC_sampler
+        sampler_cfg = {}
+    elif sampler_name.upper() == "PTLMC":
+        # -- Parallel-Tempering Langevin MC Sampler
+        sampler = PTLMC_sampler
+        sampler_cfg = {
+            "numtemps": test_setup["Sampler"]["numtemps"],
+            "numchain": test_setup["Sampler"]["numchain"],
+            "sampperchain": test_setup["Sampler"]["sampperchain"],
+            "maxtemp": test_setup["Sampler"]["maxtemp"]
+        }
     else:
-        step_scale = None
+        raise ValueError(f"Unsupported sampler ({sampler_name})")
 
-    sampler = MH_sampler
-    sampler_cfg = {"stepType": step_type, "stepParam": step_scale}
-
-    return sampler, sampler_cfg
+    return sampler_name, sampler, sampler_cfg

--- a/tools/load_mcmc_results.py
+++ b/tools/load_mcmc_results.py
@@ -8,14 +8,15 @@ from pathlib import Path
 def load_mcmc_results(filename):
     GROUP = "/MCMC"
 
+    results = {}
+
     fname = Path(filename).resolve()
     with h5py.File(fname, "r") as fptr:
-        method = fptr[GROUP].attrs["Method"]
-        assert method == "Metropolis"
-        acceptance_rate = fptr[GROUP].attrs["AcceptanceRate"]
-
         table_name = Path(GROUP).joinpath("OfficialSamples")
-        samples = np.array(fptr[str(table_name.as_posix())])
+        results["theta"] = np.array(fptr[str(table_name.as_posix())])
 
-    return {"theta": samples,
-            "acc_rate": acceptance_rate}
+        method = fptr[GROUP].attrs["Method"]
+        if method == "Metropolis":
+            results["acc_rate"] = fptr[GROUP].attrs["AcceptanceRate"]
+
+    return results

--- a/tools/save_mcmc_results.py
+++ b/tools/save_mcmc_results.py
@@ -3,7 +3,7 @@ import h5py
 from pathlib import Path
 
 
-def save_mcmc_results(filename, results, overwrite=False):
+def save_mcmc_results(filename, sampler_name, results, overwrite=False):
     GROUP = "/MCMC"
 
     fname = Path(filename).resolve()
@@ -16,8 +16,12 @@ def save_mcmc_results(filename, results, overwrite=False):
         # TODO: Add these
 
         # Method-specific configuration
-        fptr[GROUP].attrs["Method"] = "Metropolis"
-        fptr[GROUP].attrs["AcceptanceRate"] = results["acc_rate"]
-        # TODO: Add others
+        if sampler_name.upper() == "MH":
+            fptr[GROUP].attrs["Method"] = "Metropolis"
+            fptr[GROUP].attrs["AcceptanceRate"] = results["acc_rate"]
+        elif sampler_name.upper() == "LMC":
+            fptr[GROUP].attrs["Method"] = "LMC"
+        else:
+            raise ValueError(f"Unsupported sampler ({sampler_name})")
 
         fptr[GROUP].create_dataset("OfficialSamples", data=results["theta"])

--- a/tools/save_mcmc_results.py
+++ b/tools/save_mcmc_results.py
@@ -21,6 +21,8 @@ def save_mcmc_results(filename, sampler_name, results, overwrite=False):
             fptr[GROUP].attrs["AcceptanceRate"] = results["acc_rate"]
         elif sampler_name.upper() == "LMC":
             fptr[GROUP].attrs["Method"] = "LMC"
+        elif sampler_name.upper() == "PTLMC":
+            fptr[GROUP].attrs["Method"] = "PTLMC"
         else:
             raise ValueError(f"Unsupported sampler ({sampler_name})")
 

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ usedevelop = true
 commands = python -m pytest ./src/surmise/tests -k "cal"
 
 [testenv:only_sampler]
-description = Run new calibrator tests
+description = Run sampler tests
 usedevelop = true
 commands = python -m pytest ./src/surmise/tests -k "cal_samplers"
 

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,11 @@ description = Run new calibrator tests
 usedevelop = true
 commands = python -m pytest ./src/surmise/tests -k "cal"
 
+[testenv:only_sampler]
+description = Run new calibrator tests
+usedevelop = true
+commands = python -m pytest ./src/surmise/tests -k "cal_samplers"
+
 [testenv:report]
 description = Generate coverage report as HTML
 depends = coverage


### PR DESCRIPTION
The PTLMC sampler is now using an optional RNG for deterministic sampling.  The dimension mismatches are now corrected in PTLMC. 

PR Self-Review

- [x] Review all changes made here
- [x] Generate a new set of PTLMC 1D/2D benchmarks

For both `PTLMC` sampler:
- [x] Rerun tool to confirm correctness/determinism
- [x] Change a random seed and confirm that the test fails as expected
- [x] Comment out resetting of RNG for second sampling pass and see test fail as expected
- [x] Confirm all actions passing
