### PR TITLE
Don't let failed texlive installations run forever

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build_pypkg_sphinx:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         # We would like to use 3.12, but this presently fails with the error:


### PR DESCRIPTION
Attempts to install texlive from a container have failed so far (Issue #187).  Rather than continue down that road, for now we try this simple workaround to decrease wasted time and energy.

PR Self-review

- [x] Review all changes
- [x] Confirm all actions running
   * No timeout mentioned in action's log.  Time will tell if this works as expected.